### PR TITLE
separate the docx configuration from the docx file generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mohtasham/md-to-docx",
-  "version": "1.4.9",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mohtasham/md-to-docx",
-      "version": "1.4.9",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "docx": "^9.5.0",


### PR DESCRIPTION
added an entry point to allow retrieving just the input config to the docx Document object