### PR TITLE
Fix: Convert inline urls into hyperlinks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mohtasham/md-to-docx",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mohtasham/md-to-docx",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "docx": "^9.5.0",


### PR DESCRIPTION
This PR provides a fix that allows markdown urls in text to be converted to hyperlinks