### PR TITLE
fix: add columnWidths to table for proper auto-fit width

### DIFF
--- a/src/renderers/tableRenderer.ts
+++ b/src/renderers/tableRenderer.ts
@@ -64,7 +64,9 @@ export function processTable(
   // Calculate column widths (using DXA units)
   // Default A4 page content width is approximately 9026 DXA (about 15.9cm)
   const pageWidth = 9026;
-  const columnCount = tableData.headers.length;
+  // Derive max column count from headers and all rows to handle mismatches
+  const maxRowLength = tableData.rows.reduce((max, row) => Math.max(max, row.length), 0);
+  const columnCount = Math.max(tableData.headers.length, maxRowLength, 1); // Ensure at least 1 column
   const columnWidth = Math.floor(pageWidth / columnCount);
   const columnWidths = Array(columnCount).fill(columnWidth);
 


### PR DESCRIPTION
## Summary

- Fix table columns rendering too narrow by adding explicit `columnWidths` array
- Calculate equal column widths based on A4 page content width (9026 DXA)
- Set `width` property on each `TableCell` using DXA units for better compatibility

## Problem

Tables were rendering with very narrow columns, causing content to be squeezed vertically (one character per line). This happened because the docx library requires explicit `columnWidths` to properly calculate column widths.

## Solution

Added column width calculation in `processTable()`:

```typescript
const pageWidth = 9026; // A4 page content width in DXA
const columnCount = tableData.headers.length;
const columnWidth = Math.floor(pageWidth / columnCount);
const columnWidths = Array(columnCount).fill(columnWidth);
```

Then applied `columnWidths` to the Table and `width` to each TableCell.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Project builds successfully (`npm run build`)
- [ ] Manual verification: convert markdown table to docx and check column widths

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Table rendering updated to compute and apply fixed column widths based on headers and row content, yielding consistent header and cell widths and more predictable table layout across pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->