### PR TITLE
Template and sections support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New template + sections API (`options.template`, `options.sections`) for real multi-section document generation.
+- Per-section header/footer slots (`default`, `first`, `even`) with optional page-number field rendering.
+- Section-level page numbering controls (`start`, `formatType`, `separator`, and display strategy).
+- Section-level style overrides so formatting can change mid-document (addresses GitHub issue #16 use case).
+
+### Changed
+
+- `parseToDocxOptions` now emits real DOCX section entries instead of forcing a single continuous section.
+- Numbered-list sequence IDs are offset per rendered section to avoid cross-section numbering collisions.
+
+### Tests
+
+- Added `tests/sections.test.ts` covering section properties, footer behavior, numbering resets, and per-section style conversion.
+
 ## [2.8.0] - 2026-02-24
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,29 @@ import {
   PageOrientation,
   Packer,
   Table,
-  PageBreak,
   InternalHyperlink,
+  Header,
   Footer,
   PageNumber,
+  NumberFormat,
+  PageNumberSeparator,
+  SectionType,
   LevelFormat,
   IPropertiesOptions,
+  ISectionOptions,
 } from "docx";
 import saveAs from "file-saver";
-import { Options, Style } from "./types.js";
+import {
+  AlignmentOption,
+  DocumentSection,
+  HeaderFooterGroup,
+  HeaderFooterSlot,
+  Options,
+  SectionConfig,
+  SectionPageNumberDisplay,
+  SectionTemplate,
+  Style,
+} from "./types.js";
 import { parseMarkdownToAst, applyTextReplacements } from "./markdownAst.js";
 import { mdastToDocxModel } from "./mdastToDocxModel.js";
 import { modelToDocx } from "./modelToDocx.js";
@@ -33,7 +47,16 @@ const defaultOptions: Options = {
   style: defaultStyle,
 };
 
-export { Options, TableData } from "./types.js";
+export {
+  DocumentSection,
+  HeaderFooterContent,
+  HeaderFooterGroup,
+  Options,
+  SectionConfig,
+  SectionTemplate,
+  Style,
+  TableData,
+} from "./types.js";
 
 /**
  * Custom error class for markdown conversion errors
@@ -64,57 +87,693 @@ function normalizeStyleInput(style?: Partial<Style>): Partial<Style> | undefined
   };
 }
 
+const defaultSectionMargins = {
+  top: 1440,
+  right: 1080,
+  bottom: 1440,
+  left: 1080,
+};
+
+type TocHeadingEntry = { text: string; level: number; bookmarkId: string };
+type ResolvedPageNumbering = NonNullable<SectionConfig["pageNumbering"]>;
+
+interface ResolvedSectionInput {
+  markdown: string;
+  style: Style;
+  config: SectionConfig;
+}
+
+function resolveFontFamily(style: Style): string | undefined {
+  return style.fontFamily || style.fontFamilly;
+}
+
+function normalizeSectionConfig<T extends SectionConfig>(
+  section?: T
+): T | undefined {
+  if (!section) {
+    return section;
+  }
+
+  return {
+    ...section,
+    style: normalizeStyleInput(section.style),
+  };
+}
+
+function mergeHeaderFooterSlot(
+  templateSlot: HeaderFooterSlot | undefined,
+  sectionSlot: HeaderFooterSlot | undefined
+): HeaderFooterSlot | undefined {
+  if (sectionSlot === null) {
+    return null;
+  }
+  if (sectionSlot === undefined) {
+    return templateSlot;
+  }
+  if (templateSlot && typeof templateSlot === "object") {
+    return {
+      ...templateSlot,
+      ...sectionSlot,
+    };
+  }
+  return sectionSlot;
+}
+
+function mergeHeaderFooterGroup(
+  templateGroup?: HeaderFooterGroup,
+  sectionGroup?: HeaderFooterGroup
+): HeaderFooterGroup | undefined {
+  if (!templateGroup && !sectionGroup) {
+    return undefined;
+  }
+
+  const mergedGroup: HeaderFooterGroup = {
+    default: mergeHeaderFooterSlot(templateGroup?.default, sectionGroup?.default),
+    first: mergeHeaderFooterSlot(templateGroup?.first, sectionGroup?.first),
+    even: mergeHeaderFooterSlot(templateGroup?.even, sectionGroup?.even),
+  };
+
+  if (
+    mergedGroup.default === undefined &&
+    mergedGroup.first === undefined &&
+    mergedGroup.even === undefined
+  ) {
+    return undefined;
+  }
+
+  return mergedGroup;
+}
+
+function mergeSectionConfig(
+  template?: SectionTemplate,
+  section?: SectionConfig
+): SectionConfig {
+  const mergedStyle = {
+    ...(template?.style || {}),
+    ...(section?.style || {}),
+  };
+  const mergedPageMargins = {
+    ...(template?.page?.margin || {}),
+    ...(section?.page?.margin || {}),
+  };
+  const mergedPageSize = {
+    ...(template?.page?.size || {}),
+    ...(section?.page?.size || {}),
+  };
+  const mergedPage = {
+    ...(template?.page || {}),
+    ...(section?.page || {}),
+    ...(Object.keys(mergedPageMargins).length > 0
+      ? { margin: mergedPageMargins }
+      : {}),
+    ...(Object.keys(mergedPageSize).length > 0 ? { size: mergedPageSize } : {}),
+  };
+  const mergedPageNumbering = {
+    ...(template?.pageNumbering || {}),
+    ...(section?.pageNumbering || {}),
+  };
+  const mergedHeaders = mergeHeaderFooterGroup(template?.headers, section?.headers);
+  const mergedFooters = mergeHeaderFooterGroup(template?.footers, section?.footers);
+
+  return {
+    ...(template || {}),
+    ...(section || {}),
+    ...(Object.keys(mergedStyle).length > 0 ? { style: mergedStyle } : {}),
+    ...(Object.keys(mergedPage).length > 0 ? { page: mergedPage } : {}),
+    ...(Object.keys(mergedPageNumbering).length > 0
+      ? { pageNumbering: mergedPageNumbering }
+      : {}),
+    ...(mergedHeaders ? { headers: mergedHeaders } : {}),
+    ...(mergedFooters ? { footers: mergedFooters } : {}),
+  };
+}
+
+function resolveSections(
+  markdown: string,
+  options: Options,
+  baseStyle: Style
+): ResolvedSectionInput[] {
+  const normalizedTemplate = normalizeSectionConfig(options.template);
+  const sections: DocumentSection[] =
+    options.sections && options.sections.length > 0
+      ? options.sections
+      : [{ markdown }];
+
+  return sections.map((section) => {
+    const normalizedSection = normalizeSectionConfig(section) as DocumentSection;
+    const mergedSectionConfig = mergeSectionConfig(
+      normalizedTemplate,
+      normalizedSection
+    );
+    const sectionStyle: Style = {
+      ...baseStyle,
+      ...(normalizedTemplate?.style || {}),
+      ...(normalizedSection.style || {}),
+    };
+
+    return {
+      markdown: normalizedSection.markdown,
+      style: sectionStyle,
+      config: mergedSectionConfig,
+    };
+  });
+}
+
+function validateStyleInput(
+  style: Partial<Style> | undefined,
+  styleContext: string
+): void {
+  if (!style) {
+    return;
+  }
+
+  const { titleSize, headingSpacing, paragraphSpacing, lineSpacing } = style;
+  if (titleSize !== undefined && (titleSize < 8 || titleSize > 72)) {
+    throw new MarkdownConversionError(
+      "Invalid title size: Must be between 8 and 72 points",
+      { styleContext, titleSize }
+    );
+  }
+  if (
+    headingSpacing !== undefined &&
+    (headingSpacing < 0 || headingSpacing > 720)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid heading spacing: Must be between 0 and 720 twips",
+      { styleContext, headingSpacing }
+    );
+  }
+  if (
+    paragraphSpacing !== undefined &&
+    (paragraphSpacing < 0 || paragraphSpacing > 720)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid paragraph spacing: Must be between 0 and 720 twips",
+      { styleContext, paragraphSpacing }
+    );
+  }
+  if (lineSpacing !== undefined && (lineSpacing < 1 || lineSpacing > 3)) {
+    throw new MarkdownConversionError(
+      "Invalid line spacing: Must be between 1 and 3",
+      { styleContext, lineSpacing }
+    );
+  }
+
+  if (
+    style.fontFamily !== undefined &&
+    (typeof style.fontFamily !== "string" ||
+      style.fontFamily.trim().length === 0)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid fontFamily: Must be a non-empty string",
+      { styleContext, fontFamily: style.fontFamily }
+    );
+  }
+}
+
+function validatePageNumberingInput(
+  pageNumbering: SectionConfig["pageNumbering"] | undefined,
+  context: string
+): void {
+  if (!pageNumbering) {
+    return;
+  }
+
+  if (
+    pageNumbering.start !== undefined &&
+    (!Number.isInteger(pageNumbering.start) || pageNumbering.start < 1)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid page number start: Must be an integer >= 1",
+      { context, pageNumberStart: pageNumbering.start }
+    );
+  }
+}
+
 /**
  * Validates markdown input and options
  * @throws {MarkdownConversionError} If input is invalid
  */
 function validateInput(markdown: string, options: Options): void {
-  if (!markdown || typeof markdown !== "string") {
+  if (typeof markdown !== "string") {
+    throw new MarkdownConversionError(
+      "Invalid markdown input: Markdown must be a string"
+    );
+  }
+
+  if (!options.sections && markdown.trim().length === 0) {
     throw new MarkdownConversionError(
       "Invalid markdown input: Markdown must be a non-empty string"
     );
   }
 
-  const normalizedStyle = normalizeStyleInput(options.style);
-  if (normalizedStyle) {
-    const { titleSize, headingSpacing, paragraphSpacing, lineSpacing } =
-      normalizedStyle;
-    if (titleSize && (titleSize < 8 || titleSize > 72)) {
+  validateStyleInput(normalizeStyleInput(options.style), "options.style");
+
+  const normalizedTemplate = normalizeSectionConfig(options.template);
+  if (normalizedTemplate) {
+    validateStyleInput(normalizedTemplate.style, "options.template.style");
+    validatePageNumberingInput(
+      normalizedTemplate.pageNumbering,
+      "options.template.pageNumbering"
+    );
+  }
+
+  if (options.sections) {
+    if (!Array.isArray(options.sections) || options.sections.length === 0) {
       throw new MarkdownConversionError(
-        "Invalid title size: Must be between 8 and 72 points",
-        { titleSize }
-      );
-    }
-    if (headingSpacing && (headingSpacing < 0 || headingSpacing > 720)) {
-      throw new MarkdownConversionError(
-        "Invalid heading spacing: Must be between 0 and 720 twips",
-        { headingSpacing }
-      );
-    }
-    if (paragraphSpacing && (paragraphSpacing < 0 || paragraphSpacing > 720)) {
-      throw new MarkdownConversionError(
-        "Invalid paragraph spacing: Must be between 0 and 720 twips",
-        { paragraphSpacing }
-      );
-    }
-    if (lineSpacing && (lineSpacing < 1 || lineSpacing > 3)) {
-      throw new MarkdownConversionError(
-        "Invalid line spacing: Must be between 1 and 3",
-        { lineSpacing }
+        "Invalid sections input: options.sections must contain at least one section"
       );
     }
 
-    if (
-      normalizedStyle.fontFamily !== undefined &&
-      (typeof normalizedStyle.fontFamily !== "string" ||
-        normalizedStyle.fontFamily.trim().length === 0)
-    ) {
-      throw new MarkdownConversionError(
-        "Invalid fontFamily: Must be a non-empty string",
-        { fontFamily: normalizedStyle.fontFamily }
+    options.sections.forEach((section, index) => {
+      if (!section || typeof section.markdown !== "string") {
+        throw new MarkdownConversionError(
+          "Invalid section markdown: each section must provide a markdown string",
+          { sectionIndex: index }
+        );
+      }
+
+      const normalizedSection = normalizeSectionConfig(section) as DocumentSection;
+      validateStyleInput(
+        normalizedSection.style,
+        `options.sections[${index}].style`
       );
+      validatePageNumberingInput(
+        normalizedSection.pageNumbering,
+        `options.sections[${index}].pageNumbering`
+      );
+    });
+  }
+}
+
+function resolveAlignment(
+  alignment: AlignmentOption | undefined,
+  fallback: AlignmentOption = "LEFT"
+): (typeof AlignmentType)[keyof typeof AlignmentType] {
+  const resolved = alignment || fallback;
+  return AlignmentType[resolved];
+}
+
+function resolveSectionType(
+  sectionType: SectionConfig["type"] | undefined
+): (typeof SectionType)[keyof typeof SectionType] | undefined {
+  switch (sectionType) {
+    case "NEXT_PAGE":
+      return SectionType.NEXT_PAGE;
+    case "NEXT_COLUMN":
+      return SectionType.NEXT_COLUMN;
+    case "CONTINUOUS":
+      return SectionType.CONTINUOUS;
+    case "EVEN_PAGE":
+      return SectionType.EVEN_PAGE;
+    case "ODD_PAGE":
+      return SectionType.ODD_PAGE;
+    default:
+      return undefined;
+  }
+}
+
+function resolvePageOrientation(
+  orientation: "PORTRAIT" | "LANDSCAPE" | undefined
+): (typeof PageOrientation)[keyof typeof PageOrientation] {
+  return orientation === "LANDSCAPE"
+    ? PageOrientation.LANDSCAPE
+    : PageOrientation.PORTRAIT;
+}
+
+function resolvePageNumberFormat(
+  formatType: ResolvedPageNumbering["formatType"] | undefined
+): (typeof NumberFormat)[keyof typeof NumberFormat] | undefined {
+  switch (formatType) {
+    case "decimal":
+      return NumberFormat.DECIMAL;
+    case "upperRoman":
+      return NumberFormat.UPPER_ROMAN;
+    case "lowerRoman":
+      return NumberFormat.LOWER_ROMAN;
+    case "upperLetter":
+      return NumberFormat.UPPER_LETTER;
+    case "lowerLetter":
+      return NumberFormat.LOWER_LETTER;
+    default:
+      return undefined;
+  }
+}
+
+function resolvePageNumberSeparator(
+  separator: ResolvedPageNumbering["separator"] | undefined
+): (typeof PageNumberSeparator)[keyof typeof PageNumberSeparator] | undefined {
+  switch (separator) {
+    case "hyphen":
+      return PageNumberSeparator.HYPHEN;
+    case "period":
+      return PageNumberSeparator.PERIOD;
+    case "colon":
+      return PageNumberSeparator.COLON;
+    case "emDash":
+      return PageNumberSeparator.EM_DASH;
+    case "endash":
+      return PageNumberSeparator.EN_DASH;
+    default:
+      return undefined;
+  }
+}
+
+function buildPageNumberChildren(
+  display: SectionPageNumberDisplay
+): (string | (typeof PageNumber)[keyof typeof PageNumber])[] {
+  switch (display) {
+    case "current":
+      return [PageNumber.CURRENT];
+    case "currentAndTotal":
+      return [PageNumber.CURRENT, " / ", PageNumber.TOTAL_PAGES];
+    case "currentAndSectionTotal":
+      return [PageNumber.CURRENT, " / ", PageNumber.TOTAL_PAGES_IN_SECTION];
+    case "none":
+    default:
+      return [];
+  }
+}
+
+function createHeaderFooterParagraph(
+  slot: NonNullable<HeaderFooterSlot>,
+  style: Style,
+  fallbackDisplay: SectionPageNumberDisplay,
+  fallbackAlignment: AlignmentOption
+): Paragraph {
+  const display = slot.pageNumberDisplay ?? fallbackDisplay;
+  const alignment = resolveAlignment(slot.alignment, fallbackAlignment);
+  const runChildren: (string | (typeof PageNumber)[keyof typeof PageNumber])[] =
+    [];
+  const text = slot.text || "";
+
+  if (text.length > 0) {
+    runChildren.push(text);
+    if (display !== "none") {
+      runChildren.push(" ");
     }
   }
+
+  runChildren.push(...buildPageNumberChildren(display));
+
+  if (runChildren.length === 0) {
+    runChildren.push("");
+  }
+
+  return new Paragraph({
+    alignment,
+    bidirectional: style.direction === "RTL",
+    children: [
+      new TextRun({
+        children: runChildren,
+        size: style.paragraphSize || 24,
+        font: resolveFontFamily(style),
+        rightToLeft: style.direction === "RTL",
+      }),
+    ],
+  });
+}
+
+function createHeaderFromSlot(
+  slot: HeaderFooterSlot | undefined,
+  style: Style
+): Header | undefined {
+  if (slot === undefined || slot === null) {
+    return undefined;
+  }
+
+  return new Header({
+    children: [createHeaderFooterParagraph(slot, style, "none", "LEFT")],
+  });
+}
+
+function createFooterFromSlot(
+  slot: HeaderFooterSlot | undefined,
+  style: Style,
+  defaultDisplay: SectionPageNumberDisplay,
+  defaultAlignment: AlignmentOption
+): Footer | undefined {
+  if (slot === undefined || slot === null) {
+    return undefined;
+  }
+
+  return new Footer({
+    children: [
+      createHeaderFooterParagraph(slot, style, defaultDisplay, defaultAlignment),
+    ],
+  });
+}
+
+function buildHeaders(
+  group: HeaderFooterGroup | undefined,
+  style: Style
+): ISectionOptions["headers"] | undefined {
+  if (!group) {
+    return undefined;
+  }
+
+  const headers: { default?: Header; first?: Header; even?: Header } = {};
+
+  if (group.default !== undefined) {
+    const header = createHeaderFromSlot(group.default, style);
+    if (header) {
+      headers.default = header;
+    }
+  }
+  if (group.first !== undefined) {
+    const header = createHeaderFromSlot(group.first, style);
+    if (header) {
+      headers.first = header;
+    }
+  }
+  if (group.even !== undefined) {
+    const header = createHeaderFromSlot(group.even, style);
+    if (header) {
+      headers.even = header;
+    }
+  }
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function buildFooters(
+  sectionConfig: SectionConfig,
+  style: Style
+): ISectionOptions["footers"] | undefined {
+  const defaultDisplay = sectionConfig.pageNumbering?.display || "current";
+  const defaultAlignment = sectionConfig.pageNumbering?.alignment || "CENTER";
+  const group = sectionConfig.footers;
+
+  if (!group) {
+    if (defaultDisplay === "none") {
+      return undefined;
+    }
+    const autoFooter = createFooterFromSlot(
+      {
+        pageNumberDisplay: defaultDisplay,
+        alignment: defaultAlignment,
+      },
+      style,
+      defaultDisplay,
+      defaultAlignment
+    );
+    return autoFooter ? { default: autoFooter } : undefined;
+  }
+
+  const footers: { default?: Footer; first?: Footer; even?: Footer } = {};
+
+  if (group.default !== undefined) {
+    const footer = createFooterFromSlot(
+      group.default,
+      style,
+      defaultDisplay,
+      defaultAlignment
+    );
+    if (footer) {
+      footers.default = footer;
+    }
+  }
+  if (group.first !== undefined) {
+    const footer = createFooterFromSlot(
+      group.first,
+      style,
+      defaultDisplay,
+      defaultAlignment
+    );
+    if (footer) {
+      footers.first = footer;
+    }
+  }
+  if (group.even !== undefined) {
+    const footer = createFooterFromSlot(
+      group.even,
+      style,
+      defaultDisplay,
+      defaultAlignment
+    );
+    if (footer) {
+      footers.even = footer;
+    }
+  }
+
+  return Object.keys(footers).length > 0 ? footers : undefined;
+}
+
+function buildSectionProperties(
+  sectionConfig: SectionConfig
+): NonNullable<ISectionOptions["properties"]> {
+  const pageSize = {
+    ...(sectionConfig.page?.size?.width !== undefined
+      ? { width: sectionConfig.page.size.width }
+      : {}),
+    ...(sectionConfig.page?.size?.height !== undefined
+      ? { height: sectionConfig.page.size.height }
+      : {}),
+    orientation: resolvePageOrientation(sectionConfig.page?.size?.orientation),
+  };
+
+  const resolvedFormatType = resolvePageNumberFormat(
+    sectionConfig.pageNumbering?.formatType
+  );
+  const resolvedSeparator = resolvePageNumberSeparator(
+    sectionConfig.pageNumbering?.separator
+  );
+  const pageNumberOptions = {
+    ...(sectionConfig.pageNumbering?.start !== undefined
+      ? { start: sectionConfig.pageNumbering.start }
+      : {}),
+    ...(resolvedFormatType ? { formatType: resolvedFormatType } : {}),
+    ...(resolvedSeparator ? { separator: resolvedSeparator } : {}),
+  };
+  const hasPageNumberOptions = Object.keys(pageNumberOptions).length > 0;
+  const resolvedSectionType = resolveSectionType(sectionConfig.type);
+
+  return {
+    page: {
+      margin: {
+        ...defaultSectionMargins,
+        ...(sectionConfig.page?.margin || {}),
+      },
+      size: pageSize,
+      ...(hasPageNumberOptions ? { pageNumbers: pageNumberOptions } : {}),
+    },
+    ...(sectionConfig.titlePage !== undefined
+      ? { titlePage: sectionConfig.titlePage }
+      : {}),
+    ...(resolvedSectionType ? { type: resolvedSectionType } : {}),
+  };
+}
+
+function buildTocContent(headings: TocHeadingEntry[], style: Style): Paragraph[] {
+  const tocContent: Paragraph[] = [];
+
+  if (headings.length === 0) {
+    return tocContent;
+  }
+
+  tocContent.push(
+    new Paragraph({
+      text: "Table of Contents",
+      heading: "Heading1",
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 240 },
+      bidirectional: style.direction === "RTL",
+    })
+  );
+
+  headings.forEach((heading) => {
+    let fontSize;
+    let isBold = false;
+    let isItalic = false;
+
+    switch (heading.level) {
+      case 1:
+        fontSize = style.tocHeading1FontSize || style.tocFontSize;
+        isBold = style.tocHeading1Bold !== undefined ? style.tocHeading1Bold : true;
+        isItalic = style.tocHeading1Italic || false;
+        break;
+      case 2:
+        fontSize = style.tocHeading2FontSize || style.tocFontSize;
+        isBold =
+          style.tocHeading2Bold !== undefined ? style.tocHeading2Bold : false;
+        isItalic = style.tocHeading2Italic || false;
+        break;
+      case 3:
+        fontSize = style.tocHeading3FontSize || style.tocFontSize;
+        isBold = style.tocHeading3Bold || false;
+        isItalic = style.tocHeading3Italic || false;
+        break;
+      case 4:
+        fontSize = style.tocHeading4FontSize || style.tocFontSize;
+        isBold = style.tocHeading4Bold || false;
+        isItalic = style.tocHeading4Italic || false;
+        break;
+      case 5:
+        fontSize = style.tocHeading5FontSize || style.tocFontSize;
+        isBold = style.tocHeading5Bold || false;
+        isItalic = style.tocHeading5Italic || false;
+        break;
+      default:
+        fontSize = style.tocFontSize;
+    }
+
+    if (!fontSize) {
+      fontSize = style.paragraphSize
+        ? style.paragraphSize - (heading.level - 1) * 2
+        : 24 - (heading.level - 1) * 2;
+    }
+
+    tocContent.push(
+      new Paragraph({
+        children: [
+          new InternalHyperlink({
+            anchor: heading.bookmarkId,
+            children: [
+              new TextRun({
+                text: heading.text,
+                size: fontSize,
+                bold: isBold,
+                italics: isItalic,
+                font: resolveFontFamily(style),
+              }),
+            ],
+          }),
+        ],
+        indent: { left: (heading.level - 1) * 400 },
+        spacing: { after: 120 },
+        bidirectional: style.direction === "RTL",
+      })
+    );
+  });
+
+  return tocContent;
+}
+
+function replaceTocPlaceholders(
+  children: (Paragraph | Table)[],
+  tocContent: Paragraph[],
+  tocInserted: boolean
+): { children: (Paragraph | Table)[]; tocInserted: boolean } {
+  const nextChildren: (Paragraph | Table)[] = [];
+  let inserted = tocInserted;
+
+  children.forEach((child) => {
+    if ((child as any).__isTocPlaceholder === true) {
+      if (tocContent.length > 0 && !inserted) {
+        nextChildren.push(...tocContent);
+        inserted = true;
+      } else {
+        console.warn(
+          "TOC placeholder found, but no headings collected or TOC already inserted."
+        );
+      }
+      return;
+    }
+
+    nextChildren.push(child);
+  });
+
+  return { children: nextChildren, tocInserted: inserted };
 }
 
 /**
@@ -160,131 +819,63 @@ export async function parseToDocxOptions (
     // Validate inputs early
     validateInput(markdown, options);
 
-    const { documentType = "document" } = options;
     const normalizedStyle = normalizeStyleInput(options.style);
     // Merge user-provided style with defaults
     const style: Style = { ...defaultStyle, ...normalizedStyle };
 
-    // Parse markdown to AST
-    const ast = await parseMarkdownToAst(markdown);
+    const resolvedSections = resolveSections(markdown, options, style);
+    const renderedSections: {
+      children: (Paragraph | Table)[];
+      style: Style;
+      config: SectionConfig;
+    }[] = [];
+    const headings: TocHeadingEntry[] = [];
+    let maxSequenceId = 0;
 
-    // Apply text replacements if provided
-    if (options.textReplacements && options.textReplacements.length > 0) {
-      applyTextReplacements(ast, options.textReplacements);
-    }
+    for (const section of resolvedSections) {
+      const ast = await parseMarkdownToAst(section.markdown);
 
-    // Convert AST to internal model
-    const model = mdastToDocxModel(ast, style, options);
+      if (options.textReplacements && options.textReplacements.length > 0) {
+        applyTextReplacements(ast, options.textReplacements);
+      }
 
-    // Convert model to docx objects
-    const { children: docChildren, headings, maxSequenceId } = await modelToDocx(model, style, options);
+      const model = mdastToDocxModel(ast, section.style, options);
+      const renderedModel = await modelToDocx(model, section.style, options, {
+        sequenceIdOffset: maxSequenceId,
+      });
 
-    // Generate TOC content
-    const tocContent: Paragraph[] = [];
-    if (headings.length > 0) {
-      // Optional: Add a title for the TOC
-      tocContent.push(
-        new Paragraph({
-          text: "Table of Contents",
-          heading: "Heading1", // Or a specific TOC title style
-          alignment: AlignmentType.CENTER,
-          spacing: { after: 240 },
-          bidirectional: style.direction === "RTL",
-        })
-      );
-      headings.forEach((heading) => {
-        // Determine font size based on heading level
-        let fontSize;
-        let isBold = false;
-        let isItalic = false;
+      maxSequenceId = Math.max(maxSequenceId, renderedModel.maxSequenceId);
+      headings.push(...renderedModel.headings);
 
-        // Apply level-specific styles if provided
-        switch (heading.level) {
-          case 1:
-            fontSize = style.tocHeading1FontSize || style.tocFontSize;
-            isBold =
-              style.tocHeading1Bold !== undefined
-                ? style.tocHeading1Bold
-                : true;
-            isItalic = style.tocHeading1Italic || false;
-            break;
-          case 2:
-            fontSize = style.tocHeading2FontSize || style.tocFontSize;
-            isBold =
-              style.tocHeading2Bold !== undefined
-                ? style.tocHeading2Bold
-                : false;
-            isItalic = style.tocHeading2Italic || false;
-            break;
-          case 3:
-            fontSize = style.tocHeading3FontSize || style.tocFontSize;
-            isBold = style.tocHeading3Bold || false;
-            isItalic = style.tocHeading3Italic || false;
-            break;
-          case 4:
-            fontSize = style.tocHeading4FontSize || style.tocFontSize;
-            isBold = style.tocHeading4Bold || false;
-            isItalic = style.tocHeading4Italic || false;
-            break;
-          case 5:
-            fontSize = style.tocHeading5FontSize || style.tocFontSize;
-            isBold = style.tocHeading5Bold || false;
-            isItalic = style.tocHeading5Italic || false;
-            break;
-          default:
-            fontSize = style.tocFontSize;
-        }
-
-        // Use default calculation if no specific size provided
-        if (!fontSize) {
-          fontSize = style.paragraphSize
-            ? style.paragraphSize - (heading.level - 1) * 2
-            : 24 - (heading.level - 1) * 2;
-        }
-
-        tocContent.push(
-          new Paragraph({
-            children: [
-              new InternalHyperlink({
-                anchor: heading.bookmarkId,
-                children: [
-                  new TextRun({
-                    text: heading.text,
-                    size: fontSize,
-                    bold: isBold,
-                    italics: isItalic,
-                    font: style.fontFamily,
-                  }),
-                ],
-              }),
-            ],
-            // Indentation based on heading level
-            indent: { left: (heading.level - 1) * 400 },
-            spacing: { after: 120 }, // Spacing between TOC items
-            bidirectional: style.direction === "RTL",
-          })
-        );
+      renderedSections.push({
+        children:
+          renderedModel.children.length > 0
+            ? renderedModel.children
+            : [new Paragraph({})],
+        style: section.style,
+        config: section.config,
       });
     }
 
-    // Replace placeholder with TOC content
-    const finalDocChildren: (Paragraph | Table)[] = [];
+    const tocContent = buildTocContent(headings, style);
     let tocInserted = false;
-    docChildren.forEach((child) => {
-      // Check for the marker property instead of inspecting content
-      if ((child as any).__isTocPlaceholder === true) {
-        if (tocContent.length > 0 && !tocInserted) {
-          finalDocChildren.push(...tocContent);
-          tocInserted = true; // Ensure TOC is inserted only once
-        } else {
-          // If no headings were found or TOC already inserted, remove placeholder
-          console.warn(
-            "TOC placeholder found, but no headings collected or TOC already inserted."
-          );
-        }
-      } else {
-        finalDocChildren.push(child);
-      }
+    const docSections: ISectionOptions[] = renderedSections.map((section) => {
+      const replacedTocChildren = replaceTocPlaceholders(
+        section.children,
+        tocContent,
+        tocInserted
+      );
+      tocInserted = replacedTocChildren.tocInserted;
+
+      const headers = buildHeaders(section.config.headers, section.style);
+      const footers = buildFooters(section.config, section.style);
+
+      return {
+        properties: buildSectionProperties(section.config),
+        ...(headers ? { headers } : {}),
+        ...(footers ? { footers } : {}),
+        children: replacedTocChildren.children,
+      };
     });
 
     // Create numbering configurations for all numbered list sequences
@@ -313,38 +904,7 @@ export async function parseToDocxOptions (
       numbering: {
         config: numberingConfigs,
       },
-      sections: [
-        {
-          properties: {
-            page: {
-              margin: {
-                top: 1440,
-                right: 1080,
-                bottom: 1440,
-                left: 1080,
-              },
-              size: {
-                orientation: PageOrientation.PORTRAIT,
-              },
-            },
-          },
-          footers: {
-            default: new Footer({
-              children: [
-                new Paragraph({
-                  alignment: AlignmentType.CENTER,
-                  children: [
-                    new TextRun({
-                      children: [PageNumber.CURRENT],
-                    }),
-                  ],
-                }),
-              ],
-            }),
-          },
-          children: finalDocChildren,
-        },
-      ],
+      sections: docSections,
       styles: {
         paragraphStyles: [
           {
@@ -357,7 +917,7 @@ export async function parseToDocxOptions (
               size: style.titleSize,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -377,7 +937,7 @@ export async function parseToDocxOptions (
               size: style.titleSize,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -397,7 +957,7 @@ export async function parseToDocxOptions (
               size: style.titleSize - 4,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -417,7 +977,7 @@ export async function parseToDocxOptions (
               size: style.titleSize - 8,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -437,7 +997,7 @@ export async function parseToDocxOptions (
               size: style.titleSize - 12,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -457,7 +1017,7 @@ export async function parseToDocxOptions (
               size: style.titleSize - 16,
               bold: true,
               color: "000000",
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
             paragraph: {
               spacing: {
@@ -472,7 +1032,7 @@ export async function parseToDocxOptions (
             name: "Strong",
             run: {
               bold: true,
-              font: style.fontFamily,
+              font: resolveFontFamily(style),
             },
           },
         ],

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -28,7 +28,8 @@ import {
 export async function modelToDocx(
   model: DocxDocumentModel,
   style: Style,
-  options: Options
+  options: Options,
+  renderOptions: { sequenceIdOffset?: number } = {}
 ): Promise<{
   children: (Paragraph | Table)[];
   headings: { text: string; level: number; bookmarkId: string }[];
@@ -37,6 +38,7 @@ export async function modelToDocx(
   const children: (Paragraph | Table)[] = [];
   const headings: { text: string; level: number; bookmarkId: string }[] = [];
   const documentType = options.documentType || "document";
+  const sequenceIdOffset = renderOptions.sequenceIdOffset || 0;
 
   // Track numbering sequences for nested lists
   let maxSequenceId = 0;
@@ -166,15 +168,24 @@ export async function modelToDocx(
   ): Paragraph[] {
     const paragraphs: Paragraph[] = [];
     let itemNumber = 1;
+    const adjustedSequenceId = list.sequenceId
+      ? list.sequenceId + sequenceIdOffset
+      : undefined;
 
     // Track max sequence ID
-    if (list.sequenceId && list.sequenceId > maxSequenceId) {
-      maxSequenceId = list.sequenceId;
+    if (adjustedSequenceId && adjustedSequenceId > maxSequenceId) {
+      maxSequenceId = adjustedSequenceId;
     }
 
     for (const item of list.children) {
       // Render list item content
-      const itemParagraphs = renderListItem(item, list.ordered, currentLevel, list.sequenceId, itemNumber);
+      const itemParagraphs = renderListItem(
+        item,
+        list.ordered,
+        currentLevel,
+        adjustedSequenceId,
+        itemNumber
+      );
       paragraphs.push(...itemParagraphs);
       itemNumber++;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,9 +55,152 @@ export interface Style {
   tableLayout?: "autofit" | "fixed";
 }
 
+export type AlignmentOption = "LEFT" | "CENTER" | "RIGHT" | "JUSTIFIED";
+
+export type SectionPageNumberDisplay =
+  | "none"
+  | "current"
+  | "currentAndTotal"
+  | "currentAndSectionTotal";
+
+export type SectionPageNumberFormat =
+  | "decimal"
+  | "upperRoman"
+  | "lowerRoman"
+  | "upperLetter"
+  | "lowerLetter";
+
+export type SectionPageNumberSeparator =
+  | "hyphen"
+  | "period"
+  | "colon"
+  | "emDash"
+  | "endash";
+
+export interface HeaderFooterContent {
+  /**
+   * Optional plain text rendered before page number fields.
+   */
+  text?: string;
+  /**
+   * Paragraph alignment inside the header/footer slot.
+   */
+  alignment?: AlignmentOption;
+  /**
+   * Page number field rendering strategy for this slot.
+   */
+  pageNumberDisplay?: SectionPageNumberDisplay;
+}
+
+export type HeaderFooterSlot = HeaderFooterContent | null;
+
+export interface HeaderFooterGroup {
+  default?: HeaderFooterSlot;
+  first?: HeaderFooterSlot;
+  even?: HeaderFooterSlot;
+}
+
+export interface SectionPageMargins {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+  header?: number;
+  footer?: number;
+  gutter?: number;
+}
+
+export interface SectionPageSize {
+  width?: number;
+  height?: number;
+  orientation?: "PORTRAIT" | "LANDSCAPE";
+}
+
+export interface SectionPageConfig {
+  margin?: SectionPageMargins;
+  size?: SectionPageSize;
+}
+
+export interface SectionPageNumbering {
+  /**
+   * Page number to start from in this section.
+   */
+  start?: number;
+  /**
+   * Number formatting for the section page numbers.
+   */
+  formatType?: SectionPageNumberFormat;
+  /**
+   * Number separator when chapter/page separators are used.
+   */
+  separator?: SectionPageNumberSeparator;
+  /**
+   * Footer rendering style for page numbers.
+   */
+  display?: SectionPageNumberDisplay;
+  /**
+   * Alignment for the auto-generated page number footer paragraph.
+   */
+  alignment?: AlignmentOption;
+}
+
+export interface SectionConfig {
+  /**
+   * Style override applied to content rendered inside this section.
+   */
+  style?: Partial<Style>;
+  /**
+   * Section-level page properties (size, margins, orientation).
+   */
+  page?: SectionPageConfig;
+  /**
+   * Section-level header configuration.
+   */
+  headers?: HeaderFooterGroup;
+  /**
+   * Section-level footer configuration.
+   */
+  footers?: HeaderFooterGroup;
+  /**
+   * Section-level page numbering configuration.
+   */
+  pageNumbering?: SectionPageNumbering;
+  /**
+   * Enables different first-page header/footer handling in Word.
+   */
+  titlePage?: boolean;
+  /**
+   * Word section break behavior.
+   */
+  type?:
+    | "NEXT_PAGE"
+    | "NEXT_COLUMN"
+    | "CONTINUOUS"
+    | "EVEN_PAGE"
+    | "ODD_PAGE";
+}
+
+export interface SectionTemplate extends SectionConfig {}
+
+export interface DocumentSection extends SectionConfig {
+  /**
+   * Markdown content that belongs to this section.
+   */
+  markdown: string;
+}
+
 export interface Options {
   documentType?: "document" | "report";
   style?: Partial<Style>;
+  /**
+   * Shared defaults applied to each section before per-section overrides.
+   */
+  template?: SectionTemplate;
+  /**
+   * Explicit section list. If omitted, the whole markdown input is treated
+   * as a single section using global options.
+   */
+  sections?: DocumentSection[];
   /**
    * Array of text replacements to apply to the markdown AST before conversion
    * Uses mdast-util-find-and-replace for pattern matching and replacement

--- a/tests/sections.test.ts
+++ b/tests/sections.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "@jest/globals";
+import { convertMarkdownToDocx, parseToDocxOptions } from "../src/index";
+import type { Options } from "../src/types";
+
+describe("sections API", () => {
+  it("builds distinct section properties and footer behavior", async () => {
+    const options: Options = {
+      template: {
+        pageNumbering: {
+          display: "current",
+          alignment: "RIGHT",
+        },
+      },
+      sections: [
+        {
+          markdown: "# Cover\n\nCustom cover content.",
+          footers: {
+            default: null,
+          },
+          pageNumbering: {
+            display: "none",
+          },
+          style: {
+            paragraphAlignment: "CENTER",
+          },
+        },
+        {
+          markdown: "# Body\n\nMain content starts here.",
+          footers: {
+            default: {
+              text: "Page",
+              pageNumberDisplay: "currentAndSectionTotal",
+              alignment: "RIGHT",
+            },
+          },
+          pageNumbering: {
+            start: 1,
+            formatType: "decimal",
+          },
+        },
+      ],
+    };
+
+    const docxOptions = await parseToDocxOptions("", options);
+
+    expect(docxOptions.sections).toHaveLength(2);
+    expect(docxOptions.sections[0].footers).toBeUndefined();
+    expect(docxOptions.sections[1].footers?.default).toBeDefined();
+    expect(docxOptions.sections[1].properties?.page?.pageNumbers?.start).toBe(1);
+    expect(docxOptions.sections[1].properties?.page?.pageNumbers?.formatType).toBe(
+      "decimal"
+    );
+  });
+
+  it("creates independent numbered-list references across sections", async () => {
+    const docxOptions = await parseToDocxOptions("", {
+      sections: [
+        {
+          markdown: "1. First section item\n2. Second item",
+        },
+        {
+          markdown: "1. New section item\n2. Another section item",
+        },
+      ],
+    });
+
+    expect(docxOptions.numbering?.config).toHaveLength(2);
+    expect(docxOptions.numbering?.config[0].reference).toBe("numbered-list-1");
+    expect(docxOptions.numbering?.config[1].reference).toBe("numbered-list-2");
+  });
+
+  it("supports style overrides per section during full conversion", async () => {
+    const blob = await convertMarkdownToDocx("", {
+      style: {
+        paragraphSize: 24,
+      },
+      sections: [
+        {
+          markdown: "# Section One\n\nSmaller text section.",
+          style: {
+            paragraphSize: 20,
+          },
+          pageNumbering: {
+            display: "none",
+          },
+        },
+        {
+          markdown: "# Section Two\n\nLarger text section.",
+          style: {
+            paragraphSize: 30,
+          },
+          pageNumbering: {
+            start: 1,
+          },
+        },
+      ],
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Implements a `sections` API with `template` support to enable multi-section documents.

This allows for custom cover pages, per-section headers/footers, independent page numbering, and mid-document style changes, directly addressing issue #16 for custom first-page styling.

---
<p><a href="https://cursor.com/agents/bc-8aed21f3-75d4-4d9f-9687-2b0c4badec3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aed21f3-75d4-4d9f-9687-2b0c4badec3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

