### PR TITLE
fix: harden markdown conversion security

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ await convertMarkdownToDocx(markdown, {
 });
 ```
 
+For untrusted input, prefer literal string replacements. Regex replacements are accepted only when they fit bounded safety checks; patterns with nested quantifiers or excessive length are rejected before conversion to avoid ReDoS-style stalls.
+
+Escaped link syntax such as `\[label](https://example.com)` stays plain text in the DOCX. Hyperlinks are emitted only from actual Markdown link nodes.
+
 ### RTL / bidirectional text
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -530,4 +530,4 @@ PRs and issues are welcome. A few guidelines:
 
 ---
 
-Built on top of `[docx](https://www.npmjs.com/package/docx)`, `[unified](https://unifiedjs.com)`, `[remark](https://github.com/remarkjs/remark)`, and `[lowlight](https://github.com/wooorm/lowlight)`.
+Built on top of [docx](https://www.npmjs.com/package/docx), [unified](https://unifiedjs.com), [remark](https://github.com/remarkjs/remark), and [lowlight](https://github.com/wooorm/lowlight).

--- a/src/markdownAst.ts
+++ b/src/markdownAst.ts
@@ -5,6 +5,22 @@ import { findAndReplace } from "mdast-util-find-and-replace";
 import type { Root } from "mdast";
 import type { TextReplacement } from "./types.js";
 
+const MAX_REPLACEMENTS = 50;
+const MAX_REPLACEMENT_PATTERN_LENGTH = 256;
+const MAX_REPLACEMENT_TEXT_LENGTH = 4096;
+
+function isUnsafeRegex(pattern: RegExp): boolean {
+  const source = pattern.source;
+  if (source.length > MAX_REPLACEMENT_PATTERN_LENGTH) {
+    return true;
+  }
+
+  // Reject common catastrophic-backtracking shapes such as (a+)+,
+  // ([a-z]*)+, and alternations nested inside a quantified group.
+  return /\((?:[^()\\]|\\.)*[*+](?:[^()\\]|\\.)*\)[*+{]/.test(source) ||
+    /\((?:[^()\\]|\\.)*\|(?:[^()\\]|\\.)*\)[*+{]/.test(source);
+}
+
 /**
  * Parses markdown string into an mdast AST tree
  * @param markdown - The markdown string to parse
@@ -30,7 +46,31 @@ export function applyTextReplacements(
     return ast;
   }
 
-  // Convert replacements to the format expected by mdast-util-find-and-replace
+  if (replacements.length > MAX_REPLACEMENTS) {
+    throw new Error(`textReplacements supports at most ${MAX_REPLACEMENTS} entries`);
+  }
+
+  for (const replacement of replacements) {
+    if (
+      typeof replacement.replace === "string" &&
+      replacement.replace.length > MAX_REPLACEMENT_TEXT_LENGTH
+    ) {
+      throw new Error("textReplacements replacement text is too large");
+    }
+    if (replacement.find instanceof RegExp && isUnsafeRegex(replacement.find)) {
+      throw new Error("Unsafe textReplacements RegExp rejected");
+    }
+    if (
+      typeof replacement.find === "string" &&
+      replacement.find.length > MAX_REPLACEMENT_PATTERN_LENGTH
+    ) {
+      throw new Error("textReplacements string pattern is too large");
+    }
+  }
+
+  // Convert replacements to the format expected by mdast-util-find-and-replace.
+  // RegExp entries are intentionally constrained above; string entries are the
+  // recommended mode for untrusted callers.
   const findReplacePairs: Array<[string | RegExp, string | ((...args: any[]) => any)]> = 
     replacements.map((replacement) => [
       replacement.find,
@@ -42,4 +82,3 @@ export function applyTextReplacements(
 
   return ast;
 }
-

--- a/src/markdownAst.ts
+++ b/src/markdownAst.ts
@@ -17,8 +17,8 @@ function isUnsafeRegex(pattern: RegExp): boolean {
 
   // Reject common catastrophic-backtracking shapes such as (a+)+,
   // ([a-z]*)+, and alternations nested inside a quantified group.
-  return /\((?:[^()\\]|\\.)*[*+](?:[^()\\]|\\.)*\)[*+{]/.test(source) ||
-    /\((?:[^()\\]|\\.)*\|(?:[^()\\]|\\.)*\)[*+{]/.test(source);
+  return /\((?:[^()\\]|\\.)*[*+?](?:[^()\\]|\\.)*\)[*+?{]/.test(source) ||
+    /\((?:[^()\\]|\\.)*\|(?:[^()\\]|\\.)*\)[*+?{]/.test(source);
 }
 
 /**

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -286,7 +286,7 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
           const previous = result[result.length - 1];
           if (
             previous?.type === "text" &&
-            previous.value.endsWith("](") &&
+            /\[[^\]]+\]\($/.test(previous.value) &&
             (node as Link).children.length === 1 &&
             (node as Link).children[0].type === "text" &&
             ((node as Link).children[0] as Text).value === (node as Link).url

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -224,14 +224,29 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
 
   function processInlineNodes(nodes: any[]): DocxTextNode[] {
     const result: DocxTextNode[] = [];
+
+    function pushTextWithUnderline(value: string): void {
+      const parts = value.split(/(\+\+[^+\n][\s\S]*?\+\+)/g);
+      for (const part of parts) {
+        if (part.startsWith("++") && part.endsWith("++") && part.length > 4) {
+          result.push({
+            type: "text",
+            value: part.slice(2, -2),
+            underline: true,
+          });
+        } else if (part.length > 0) {
+          result.push({
+            type: "text",
+            value: part,
+          });
+        }
+      }
+    }
     
     for (const node of nodes) {
       switch (node.type) {
         case "text":
-          result.push({
-            type: "text",
-            value: (node as Text).value,
-          });
+          pushTextWithUnderline((node as Text).value);
           break;
         case "emphasis":
           const emphasisChildren = processInlineNodes((node as Emphasis).children);
@@ -268,6 +283,17 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
           });
           break;
         case "link":
+          const previous = result[result.length - 1];
+          if (
+            previous?.type === "text" &&
+            previous.value.endsWith("](") &&
+            (node as Link).children.length === 1 &&
+            (node as Link).children[0].type === "text" &&
+            ((node as Link).children[0] as Text).value === (node as Link).url
+          ) {
+            previous.value += (node as Link).url;
+            break;
+          }
           const linkChildren = processInlineNodes((node as Link).children);
           for (const child of linkChildren) {
             result.push({
@@ -379,4 +405,3 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
 
   return { children };
 }
-

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -282,7 +282,7 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
             code: true,
           });
           break;
-        case "link":
+        case "link": {
           const previous = result[result.length - 1];
           if (
             previous?.type === "text" &&
@@ -302,6 +302,7 @@ export function mdastToDocxModel(root: Root, style: Style, options: Options): Do
             });
           }
           break;
+        }
         case "break":
           result.push({
             type: "text",

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -1,15 +1,18 @@
 import {
   Paragraph,
   Table,
+  TableRow,
+  TableCell,
   TextRun,
   ExternalHyperlink,
   PageBreak,
   AlignmentType,
+  TableLayoutType,
+  WidthType,
 } from "docx";
-import type { DocxDocumentModel, DocxBlockNode, DocxListNode, DocxListItemNode } from "./docxModel.js";
+import type { DocxDocumentModel, DocxBlockNode, DocxListNode, DocxListItemNode, DocxTextNode } from "./docxModel.js";
 import { Style, Options } from "./types.js";
 import { processHeading } from "./renderers/headingRenderer.js";
-import { processTable } from "./renderers/tableRenderer.js";
 import { processCodeBlock } from "./renderers/codeRenderer.js";
 import { processBlockquote } from "./renderers/blockquoteRenderer.js";
 import { processComment } from "./renderers/commentRenderer.js";
@@ -17,12 +20,8 @@ import {
   processImage,
   resolveImageHandlingOptions,
 } from "./renderers/imageRenderer.js";
-import { processParagraph } from "./renderers/paragraphRenderer.js";
-import {
-  processFormattedText,
-  processLinkParagraph,
-} from "./renderers/textRenderer.js";
-import { processListItem } from "./renderers/listRenderer.js";
+import { processInlineCode } from "./renderers/textRenderer.js";
+import { resolveFontFamily } from "./utils/styleUtils.js";
 
 /**
  * Converts internal docx model to docx Paragraph/Table objects
@@ -82,6 +81,174 @@ export async function modelToDocx(
     return text;
   }
 
+  function textRunFromNode(
+    node: DocxTextNode,
+    overrides: { forceBold?: boolean; size?: number } = {}
+  ): TextRun {
+    if (node.code) {
+      return processInlineCode(node.value, style);
+    }
+
+    return new TextRun({
+      text: node.value,
+      bold: overrides.forceBold || node.bold,
+      italics: node.italic,
+      strike: node.strikethrough,
+      underline: node.underline ? { type: "single" } : undefined,
+      color: node.link ? "0000FF" : "000000",
+      size: overrides.size || style.paragraphSize || 24,
+      font: resolveFontFamily(style),
+      rightToLeft: style.direction === "RTL",
+    });
+  }
+
+  function renderInlineNodes(
+    nodes: DocxTextNode[],
+    overrides: { forceBold?: boolean; size?: number } = {}
+  ): (TextRun | ExternalHyperlink)[] {
+    const out: (TextRun | ExternalHyperlink)[] = [];
+    for (const node of nodes) {
+      if (node.link) {
+        out.push(
+          new ExternalHyperlink({
+            children: [
+              new TextRun({
+                text: node.value,
+                color: "0000FF",
+                underline: { type: "single" },
+                bold: overrides.forceBold || node.bold,
+                italics: node.italic,
+                strike: node.strikethrough,
+                size: overrides.size || style.paragraphSize || 24,
+                font: resolveFontFamily(style),
+                rightToLeft: style.direction === "RTL",
+              }),
+            ],
+            link: node.link,
+          })
+        );
+      } else {
+        out.push(textRunFromNode(node, overrides));
+      }
+    }
+
+    if (out.length === 0) {
+      out.push(textRunFromNode({ type: "text", value: "" }, overrides));
+    }
+    return out;
+  }
+
+  function paragraphFromInlineNodes(nodes: DocxTextNode[]): Paragraph {
+    const alignment = style.paragraphAlignment
+      ? AlignmentType[style.paragraphAlignment]
+      : AlignmentType.LEFT;
+    return new Paragraph({
+      children: renderInlineNodes(nodes),
+      spacing: {
+        before: style.paragraphSpacing,
+        after: style.paragraphSpacing,
+        line: style.lineSpacing * 240,
+      },
+      alignment,
+      indent:
+        style.paragraphAlignment === "JUSTIFIED"
+          ? { left: 0, right: 0 }
+          : undefined,
+      bidirectional: style.direction === "RTL",
+    });
+  }
+
+  function tableFromNode(node: Extract<DocxBlockNode, { type: "table" }>): Table {
+    const layout =
+      style.tableLayout === "fixed" ? TableLayoutType.FIXED : TableLayoutType.AUTOFIT;
+    const getColumnAlignment = (
+      index: number
+    ): (typeof AlignmentType)[keyof typeof AlignmentType] => {
+      const align = node.align?.[index];
+      if (align === "center") return AlignmentType.CENTER;
+      if (align === "right") return AlignmentType.RIGHT;
+      return AlignmentType.LEFT;
+    };
+
+    return new Table({
+      width: { size: 100, type: WidthType.PERCENTAGE },
+      rows: [
+        new TableRow({
+          tableHeader: true,
+          children: node.headers.map(
+            (cell, index) =>
+              new TableCell({
+                children: [
+                  new Paragraph({
+                    alignment: getColumnAlignment(index),
+                    style: "Strong",
+                    children: renderInlineNodes(cell, { forceBold: true }),
+                  }),
+                ],
+                shading: {
+                  fill: documentType === "report" ? "DDDDDD" : "F2F2F2",
+                },
+              })
+          ),
+        }),
+        ...node.rows.map(
+          (row) =>
+            new TableRow({
+              children: row.map(
+                (cell, index) =>
+                  new TableCell({
+                    children: [
+                      new Paragraph({
+                        alignment: getColumnAlignment(index),
+                        children: renderInlineNodes(cell),
+                      }),
+                    ],
+                  })
+              ),
+            })
+        ),
+      ],
+      layout,
+      margins: {
+        top: 100,
+        bottom: 100,
+        left: 100,
+        right: 100,
+      },
+    });
+  }
+
+  function listParagraphFromInlineNodes(
+    nodes: DocxTextNode[],
+    isOrdered: boolean,
+    level: number,
+    sequenceId: number | undefined
+  ): Paragraph {
+    const base = {
+      children: renderInlineNodes(nodes, { size: style.listItemSize || 24 }),
+      spacing: {
+        before: style.paragraphSpacing / 2,
+        after: style.paragraphSpacing / 2,
+      },
+      bidirectional: style.direction === "RTL",
+    };
+
+    if (isOrdered) {
+      return new Paragraph({
+        ...base,
+        numbering: {
+          reference: `numbered-list-${sequenceId || 1}`,
+          level,
+        },
+      });
+    }
+
+    return new Paragraph({
+      ...base,
+      bullet: { level },
+    });
+  }
+
   function renderBlockNode(
     node: DocxBlockNode,
     listLevel: number = 0
@@ -112,8 +279,7 @@ export async function modelToDocx(
       }
 
       case "paragraph": {
-        const paragraphText = node.children.map((c) => encodeInlineNode(c)).join("");
-        return [processParagraph(paragraphText, style)];
+        return [paragraphFromInlineNodes(node.children)];
       }
 
       case "list": {
@@ -149,16 +315,7 @@ export async function modelToDocx(
       }
 
       case "table": {
-        const tableData = {
-          headers: node.headers.map(
-            (cells) => cells.map((c) => encodeInlineNode(c)).join("")
-          ),
-          rows: node.rows.map((row) =>
-            row.map((cells) => cells.map((c) => encodeInlineNode(c)).join(""))
-          ),
-          align: node.align,
-        };
-        return [processTable(tableData, documentType, style)];
+        return [tableFromNode(node)];
       }
 
       case "comment": {
@@ -227,20 +384,9 @@ export async function modelToDocx(
         const nestedParagraphs = renderList(child as DocxListNode, level + 1);
         paragraphs.push(...nestedParagraphs);
       } else if (child.type === "paragraph") {
-        // Paragraph content - render as list item
-        const paragraphText = child.children
-          .map((c) => encodeInlineNode(c))
-          .join("");
-
-        // Use processListItem helper
-        const listItemConfig = {
-          text: paragraphText,
-          isNumbered: isOrdered,
-          listNumber: itemNumber,
-          sequenceId: sequenceId || 1,
-          level: level,
-        };
-        paragraphs.push(processListItem(listItemConfig, style));
+        paragraphs.push(
+          listParagraphFromInlineNodes(child.children, isOrdered, level, sequenceId)
+        );
       } else {
         // Other block types - render normally but they'll appear as part of list item
         const rendered = renderBlockNode(child, level);
@@ -255,14 +401,9 @@ export async function modelToDocx(
 
     // If no paragraphs were created, create an empty list item
     if (paragraphs.length === 0) {
-      const listItemConfig = {
-        text: "",
-        isNumbered: isOrdered,
-        listNumber: itemNumber,
-        sequenceId: sequenceId || 1,
-        level: level,
-      };
-      paragraphs.push(processListItem(listItemConfig, style));
+      paragraphs.push(
+        listParagraphFromInlineNodes([], isOrdered, level, sequenceId)
+      );
     }
 
     return paragraphs;

--- a/src/renderers/textRenderer.ts
+++ b/src/renderers/textRenderer.ts
@@ -20,6 +20,20 @@ function hasUnescapedMarker(text: string, marker: string, startIndex: number): b
   return false;
 }
 
+function findUnescaped(text: string, needle: string, startIndex: number): number {
+  const maxIndex = text.length - needle.length;
+  for (let i = startIndex; i <= maxIndex; i++) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i++;
+      continue;
+    }
+    if (text.substring(i, i + needle.length) === needle) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 /**
  * Processes inline code and returns a TextRun object
  * @param code - The inline code text
@@ -67,6 +81,7 @@ export function processFormattedText(
   let underlineStart = -1;
   let strikethroughStart = -1;
   const fontFamily = resolveFontFamily(style);
+  let nextPossibleLinkStart = 0;
 
   function createTextRun(value: string): TextRun {
     return new TextRun({
@@ -112,31 +127,13 @@ export function processFormattedText(
     }
 
     // Handle inline links [text](url) - only when not in inline code
-    if (!isInlineCode && line[j] === "[") {
-      let closeBracket = -1;
-      let openParen = -1;
-      let closeParen = -1;
-
-      for (let k = j + 1; k < line.length; k++) {
-        if (line[k] === "\\" && k + 1 < line.length) {
-          k++;
-          continue;
-        }
-        if (line[k] === "]") {
-          closeBracket = k;
-          break;
-        }
-      }
-
-      if (closeBracket > j && closeBracket + 1 < line.length && line[closeBracket + 1] === "(") {
-        openParen = closeBracket + 1;
-        for (let k = openParen + 1; k < line.length; k++) {
-          if (line[k] === ")") {
-            closeParen = k;
-            break;
-          }
-        }
-      }
+    if (!isInlineCode && line[j] === "[" && j >= nextPossibleLinkStart) {
+      const closeBracket = findUnescaped(line, "]", j + 1);
+      const openParen =
+        closeBracket > j && closeBracket + 1 < line.length && line[closeBracket + 1] === "("
+          ? closeBracket + 1
+          : -1;
+      const closeParen = openParen > 0 ? findUnescaped(line, ")", openParen + 1) : -1;
 
       if (closeBracket > j && openParen > closeBracket && closeParen > openParen) {
         flushCurrentText();
@@ -165,6 +162,12 @@ export function processFormattedText(
 
         j = closeParen;
         continue;
+      }
+
+      if (closeBracket === -1) {
+        nextPossibleLinkStart = line.length;
+      } else {
+        nextPossibleLinkStart = closeBracket + 1;
       }
     }
 

--- a/src/utils/codeHighlight.ts
+++ b/src/utils/codeHighlight.ts
@@ -86,6 +86,7 @@ const aliasToCanonical = new Map<string, string>();
 const negativeLanguageLookups = new Set<string>();
 const MAX_LANGUAGE_NAME_LENGTH = 64;
 const MAX_LANGUAGE_WHITELIST_SIZE = 128;
+const MAX_NEGATIVE_LANGUAGE_LOOKUPS = 2048;
 
 let aliasMap: Map<string, string> | undefined;
 
@@ -142,6 +143,16 @@ function getAliasMap(): Map<string, string> {
   return aliasMap;
 }
 
+function cacheNegativeLanguageLookup(name: string): void {
+  if (negativeLanguageLookups.size >= MAX_NEGATIVE_LANGUAGE_LOOKUPS) {
+    const oldest = negativeLanguageLookups.values().next().value;
+    if (oldest) {
+      negativeLanguageLookups.delete(oldest);
+    }
+  }
+  negativeLanguageLookups.add(name);
+}
+
 /**
  * Resolve a user-supplied language name to the canonical lowlight
  * grammar key it belongs to, handling alias spellings like `js`, `sh`,
@@ -174,7 +185,7 @@ export function canonicalLanguageName(name: string): string | null {
     aliasToCanonical.set(normalized, canonical);
     return canonical;
   }
-  negativeLanguageLookups.add(normalized);
+  cacheNegativeLanguageLookup(normalized);
   return null;
 }
 

--- a/src/utils/codeHighlight.ts
+++ b/src/utils/codeHighlight.ts
@@ -83,6 +83,64 @@ const instanceCache = new Map<string, LowlightInstance>();
  * the probe cost more than once per alias.
  */
 const aliasToCanonical = new Map<string, string>();
+const negativeLanguageLookups = new Set<string>();
+const MAX_LANGUAGE_NAME_LENGTH = 64;
+const MAX_LANGUAGE_WHITELIST_SIZE = 128;
+
+let aliasMap: Map<string, string> | undefined;
+
+const COMMON_LANGUAGE_ALIASES: Record<string, string> = {
+  cjs: "javascript",
+  hbs: "handlebars",
+  hs: "haskell",
+  js: "javascript",
+  kts: "kotlin",
+  md: "markdown",
+  mjs: "javascript",
+  ps: "powershell",
+  ps1: "powershell",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  sh: "bash",
+  shell: "bash",
+  ts: "typescript",
+  yml: "yaml",
+  "c++": "cpp",
+};
+
+function normalizedLanguageName(name: string): string | null {
+  const normalized = name.trim().toLowerCase();
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_LANGUAGE_NAME_LENGTH
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function getAliasMap(): Map<string, string> {
+  if (aliasMap) {
+    return aliasMap;
+  }
+
+  aliasMap = new Map();
+  const lookup = common as Record<string, CommonGrammar>;
+  for (const canonical of Object.keys(lookup)) {
+    const probe = createLowlight({ [canonical]: lookup[canonical] });
+    aliasMap.set(canonical, canonical);
+    for (const registered of probe.listLanguages()) {
+      aliasMap.set(registered, canonical);
+    }
+  }
+  for (const [alias, canonical] of Object.entries(COMMON_LANGUAGE_ALIASES)) {
+    if (canonical in lookup) {
+      aliasMap.set(alias, canonical);
+    }
+  }
+  return aliasMap;
+}
 
 /**
  * Resolve a user-supplied language name to the canonical lowlight
@@ -97,21 +155,26 @@ const aliasToCanonical = new Map<string, string>();
  * runs the first time a given alias is encountered.
  */
 export function canonicalLanguageName(name: string): string | null {
-  if (name in common) {
-    return name;
+  const normalized = normalizedLanguageName(name);
+  if (!normalized) {
+    return null;
   }
-  const cached = aliasToCanonical.get(name);
+  if (normalized in common) {
+    return normalized;
+  }
+  const cached = aliasToCanonical.get(normalized);
   if (cached) {
     return cached;
   }
-  const lookup = common as Record<string, CommonGrammar>;
-  for (const canonical of Object.keys(lookup)) {
-    const probe = createLowlight({ [canonical]: lookup[canonical] });
-    if (probe.registered(name)) {
-      aliasToCanonical.set(name, canonical);
-      return canonical;
-    }
+  if (negativeLanguageLookups.has(normalized)) {
+    return null;
   }
+  const canonical = getAliasMap().get(normalized);
+  if (canonical) {
+    aliasToCanonical.set(normalized, canonical);
+    return canonical;
+  }
+  negativeLanguageLookups.add(normalized);
   return null;
 }
 
@@ -137,7 +200,8 @@ export function getLowlightInstance(languages?: string[]): LowlightInstance {
   // fences. Duplicates after canonicalization are also collapsed.
   const lookup = common as Record<string, CommonGrammar>;
   const canonicalSet = new Set<string>();
-  for (const name of languages) {
+  const boundedLanguages = languages.slice(0, MAX_LANGUAGE_WHITELIST_SIZE);
+  for (const name of new Set(boundedLanguages)) {
     const canonical = canonicalLanguageName(name);
     if (canonical) {
       canonicalSet.add(canonical);

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  convertMarkdownToDocx,
+  MarkdownConversionError,
+} from "../src/index";
+import { canonicalLanguageName } from "../src/utils/codeHighlight";
+import { processFormattedText } from "../src/renderers/textRenderer";
+import { getDocumentXml, getZip } from "./helpers";
+
+async function documentRelationshipsXml(blob: Blob): Promise<string> {
+  const zip = await getZip(blob);
+  return zip.file("word/_rels/document.xml.rels")?.async("string") ?? "";
+}
+
+describe("Security regressions", () => {
+  it("does not turn escaped link syntax into a DOCX hyperlink", async () => {
+    const blob = await convertMarkdownToDocx(
+      String.raw`Escaped \[not a link](https://example.com/phish).`
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("not a link");
+    expect(documentXml).not.toContain("<w:hyperlink");
+    expect(relationshipsXml).not.toContain("https://example.com/phish");
+  });
+
+  it("still renders intentional markdown links as DOCX hyperlinks", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Real [link](https://example.com/docs)."
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("<w:hyperlink");
+    expect(relationshipsXml).toContain("https://example.com/docs");
+  });
+
+  it("rejects nested-quantifier text replacement regexes before replacement", async () => {
+    await expect(
+      convertMarkdownToDocx("a".repeat(2000), {
+        textReplacements: [{ find: /(a+)+$/, replace: "safe" }],
+      })
+    ).rejects.toBeInstanceOf(MarkdownConversionError);
+  });
+
+  it("bounds link scanning for bracket-heavy fallback rendering", () => {
+    const runs = processFormattedText("[".repeat(20_000));
+    expect(runs.length).toBeGreaterThan(0);
+  });
+
+  it("caches and bounds unknown code highlighting language resolution", () => {
+    for (let i = 0; i < 1_000; i++) {
+      expect(canonicalLanguageName(`unknown-language-${i}`)).toBeNull();
+    }
+    expect(canonicalLanguageName("javascript")).toBe("javascript");
+    expect(canonicalLanguageName("js")).toBe("javascript");
+  });
+});

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -46,6 +46,14 @@ describe("Security regressions", () => {
     ).rejects.toBeInstanceOf(MarkdownConversionError);
   });
 
+  it("rejects nested optional-quantifier text replacement regexes", async () => {
+    await expect(
+      convertMarkdownToDocx("a".repeat(2000), {
+        textReplacements: [{ find: /(a?)+$/, replace: "safe" }],
+      })
+    ).rejects.toBeInstanceOf(MarkdownConversionError);
+  });
+
   it("bounds link scanning for bracket-heavy fallback rendering", () => {
     const runs = processFormattedText("[".repeat(20_000));
     expect(runs.length).toBeGreaterThan(0);

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -38,6 +38,18 @@ describe("Security regressions", () => {
     expect(relationshipsXml).toContain("https://example.com/docs");
   });
 
+  it("keeps GFM autolinks after text ending in bracket-paren syntax", async () => {
+    const blob = await convertMarkdownToDocx(
+      "See result](https://example.com/autolink) for details."
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("<w:hyperlink");
+    expect(relationshipsXml).toContain("https://example.com/autolink");
+  });
+
   it("rejects nested-quantifier text replacement regexes before replacement", async () => {
     await expect(
       convertMarkdownToDocx("a".repeat(2000), {


### PR DESCRIPTION
## Summary
- harden textReplacements against ReDoS-style regexes and oversized replacement configs
- render structured inline nodes directly so escaped link-like text does not become DOCX hyperlinks
- bound fallback inline link scanning and code highlighting language resolution
- document untrusted-input behavior and add regression coverage

Fixes #47
Fixes #48
Fixes #49
Fixes #50

## Verification
- npm run build
- npm test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated guidance on handling text replacements and escaped Markdown link syntax

* **New Features**
  - Added `++...++` syntax to underline text spans within documents

* **Bug Fixes**
  - Escaped Markdown link syntax now renders as plain text instead of converting to hyperlinks
  - Text replacement patterns are now subject to validation constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MohtashamMurshid/md-to-docx/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rendering and pre-processing paths (text replacement validation, inline/link rendering, table/list generation), so output formatting and hyperlink behavior may change subtly. Changes are defensive but affect security-sensitive handling of untrusted input and performance edge cases.
> 
> **Overview**
> Strengthens `textReplacements` by enforcing hard limits (max entries/lengths) and rejecting unsafe regex patterns before AST mutation to reduce ReDoS-style stalls.
> 
> Changes inline rendering to rely on structured mdast nodes rather than markdown-like re-parsing, ensuring escaped link-like text (e.g. `\[label](url)`) stays plain text while real Markdown link nodes still produce DOCX hyperlinks; also adds underline handling for `++...++` spans.
> 
> Bounds worst-case work in fallback parsing (`processFormattedText` link scanning) and in code highlighting language resolution by normalizing names, caching negative lookups, precomputing alias mappings, and capping language whitelist size. Adds security regression tests and updates README guidance for untrusted input and escaped link behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3316816f66a7029b1cd8fab19e175950fd992dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->