### PR TITLE
fix: remove library console diagnostics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1025,10 +1025,6 @@ function replaceTocPlaceholders(
       if (tocContent.length > 0 && !inserted) {
         nextChildren.push(...tocContent);
         inserted = true;
-      } else {
-        console.warn(
-          "TOC placeholder found, but no headings collected or TOC already inserted."
-        );
       }
       return;
     }
@@ -1342,7 +1338,6 @@ export function downloadDocx(
   try {
     saveAs(blob, filename);
   } catch (error) {
-    console.error("Failed to save file:", error);
     throw new Error(
       `Failed to save file: ${
         error instanceof Error ? error.message : "Unknown error"

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import {
   convertMarkdownToDocx,
   MarkdownConversionError,
@@ -13,6 +13,20 @@ async function documentRelationshipsXml(blob: Blob): Promise<string> {
 }
 
 describe("Security regressions", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not write diagnostics to console during library conversion", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await convertMarkdownToDocx("# Title\n\n[[toc]]");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
   it("does not turn escaped link syntax into a DOCX hyperlink", async () => {
     const blob = await convertMarkdownToDocx(
       String.raw`Escaped \[not a link](https://example.com/phish).`


### PR DESCRIPTION
## Summary
- remove library-side console.warn/error calls from DOCX conversion and download error handling
- preserve existing control flow while avoiding consumer I/O side effects
- add a regression test that convertMarkdownToDocx does not write diagnostics to console

Closes #33

## Tests
- npm test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Document download failures now properly throw errors with clear error messages instead of silently failing
  * Table of contents generation no longer produces unnecessary console warnings during normal operation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MohtashamMurshid/md-to-docx/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->