### PR TITLE
fix(tables): emit integer table width to avoid Word 2007 corruption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   buildFooters,
   buildHeaders,
   buildSectionProperties,
+  getSectionContentWidthTwips,
   normalizeStyleInput,
   resolveSections,
 } from "./sectionBuilder.js";
@@ -146,6 +147,7 @@ export async function parseToDocxOptions(
         processedImageCounter,
         headingBookmarkCounter,
         tocPlaceholders,
+        tableWidthTwips: getSectionContentWidthTwips(section.config),
       });
 
       maxSequenceId = Math.max(maxSequenceId, renderedModel.maxSequenceId);

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -46,6 +46,12 @@ export async function modelToDocx(
     headingBookmarkCounter?: { count: number };
     /** Records emitted TOC placeholder paragraphs so the caller can splice in TOC content. */
     tocPlaceholders?: WeakSet<object>;
+    /**
+     * Usable content width of the section in twips. Tables are sized with this
+     * value (as {@link WidthType.DXA}) so they emit a plain integer width,
+     * avoiding the percentage form that Word 2007 treats as corrupt.
+     */
+    tableWidthTwips?: number;
   } = {}
 ): Promise<{
   children: (Paragraph | Table)[];
@@ -60,6 +66,9 @@ export async function modelToDocx(
   const processedImageCounter = renderOptions.processedImageCounter ?? {
     count: 0,
   };
+  // Full-width tables are sized in twips so docx emits a plain integer width.
+  // Defaults to A4 portrait content width (page 11906 - default 1080 margins).
+  const tableWidthTwips = renderOptions.tableWidthTwips ?? 9746;
 
   // Track numbering sequences for nested lists
   let maxSequenceId = 0;
@@ -157,7 +166,7 @@ export async function modelToDocx(
     };
 
     return new Table({
-      width: { size: 100, type: WidthType.PERCENTAGE },
+      width: { size: tableWidthTwips, type: WidthType.DXA },
       rows: [
         new TableRow({
           tableHeader: true,

--- a/src/sectionBuilder.ts
+++ b/src/sectionBuilder.ts
@@ -35,6 +35,35 @@ const defaultSectionMargins = {
   left: 1080,
 };
 
+// docx page-size defaults (A4 portrait), expressed in twips.
+const DEFAULT_PAGE_WIDTH_TWIPS = 11906;
+const DEFAULT_PAGE_HEIGHT_TWIPS = 16838;
+
+/**
+ * Computes the usable content width of a section in twips (page width minus
+ * left/right margins), mirroring how docx resolves the displayed page width
+ * (the longer edge is used as the width in landscape orientation).
+ *
+ * Tables are sized with this value using {@link WidthType.DXA} so they emit a
+ * plain integer width. The percentage form produced by docx
+ * (`<w:tblW w:type="pct" w:w="100%"/>`) is rejected as corrupt by Word 2007,
+ * which expects fiftieths of a percent rather than a literal percentage.
+ */
+export function getSectionContentWidthTwips(config: SectionConfig): number {
+  const size = config.page?.size;
+  const width = size?.width ?? DEFAULT_PAGE_WIDTH_TWIPS;
+  const height = size?.height ?? DEFAULT_PAGE_HEIGHT_TWIPS;
+  const orientation = resolvePageOrientation(size?.orientation);
+  const displayedWidth =
+    orientation === PageOrientation.LANDSCAPE ? height : width;
+
+  const margins = { ...defaultSectionMargins, ...(config.page?.margin || {}) };
+  const left = margins.left ?? defaultSectionMargins.left;
+  const right = margins.right ?? defaultSectionMargins.right;
+
+  return Math.max(1, Math.floor(displayedWidth - left - right));
+}
+
 export interface ResolvedSectionInput {
   markdown: string;
   style: Style;

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -297,6 +297,47 @@ describe("Rendering: tables", () => {
     // fixed layout should include tblLayout type="fixed"
     expect(xmlFixed).toMatch(/<w:tblLayout[^>]*w:type="fixed"/);
   });
+
+  it("emits an integer table width that Word 2007 accepts (no percentage form)", async () => {
+    const markdown = `| A | B |
+|---|---|
+| 1 | 2 |`;
+
+    const xml = await render(markdown);
+
+    const match = xml.match(/<w:tblW\b[^>]*\/>/);
+    expect(match).not.toBeNull();
+    const tblW = match![0];
+
+    // Word 2007 rejects the percentage form (e.g. w:w="100%") as corrupt; the
+    // width must be a plain integer. See issue #64.
+    expect(tblW).not.toContain("%");
+    const wValue = tblW.match(/w:w="([^"]+)"/)?.[1];
+    expect(wValue).toBeDefined();
+    expect(wValue).toMatch(/^\d+$/);
+  });
+
+  it("scales table width to the configured page size and margins", async () => {
+    const markdown = `| A | B |
+|---|---|
+| 1 | 2 |`;
+
+    const xml = await render(markdown, {
+      sections: [
+        {
+          markdown,
+          page: {
+            size: { width: 12240, height: 15840 },
+            margin: { left: 1440, right: 1440 },
+          },
+        },
+      ],
+    });
+
+    const wValue = xml.match(/<w:tblW\b[^>]*w:w="([^"]+)"/)?.[1];
+    // 12240 (US Letter) - 1440 - 1440 = 9360 twips of usable width.
+    expect(wValue).toBe("9360");
+  });
 });
 
 describe("Rendering: images", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #64.

When a document contains a table, the `.docx` is reported as **corrupted by MS Word 2007**. The offending markup is the table width:

```xml
<w:tblW w:type="pct" w:w="100%"/>
```

For `w:type="pct"`, Word 2007 expects an integer expressed in *fiftieths of a percent* (e.g. `5000` for 100%), not a literal `100%` string. The `docx` library always serializes percentage table widths in the literal form and offers no public API to force the integer form (confirmed in `docx` `9.5.x`–`9.7.x`: `TableWidthElement` converts a numeric `PERCENTAGE` size to `` `${size}%` ``).

## Fix

Since we can't change how `docx` serializes percentages, tables are now sized in **twips** using `WidthType.DXA`, based on the section's usable content width (page width − left/right margins, accounting for landscape orientation the same way `docx` does). This produces a plain integer width that is valid across all Word versions while preserving full-width tables.

Output before:

```xml
<w:tblW w:type="pct" w:w="100%"/>
```

Output after (A4 portrait, default margins):

```xml
<w:tblW w:type="dxa" w:w="9746"/>
```

## Changes

- `src/sectionBuilder.ts`: new exported `getSectionContentWidthTwips(config)` helper that mirrors docx's effective page-width resolution.
- `src/index.ts`: passes the per-section content width into `modelToDocx`.
- `src/modelToDocx.ts`: tables now use `{ size: tableWidthTwips, type: WidthType.DXA }` (defaults to A4 portrait content width when not provided).
- `tests/rendering.test.ts`: added tests asserting the table width is a percentage-free integer and that it scales with configured page size/margins.

## Testing

- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ (90 passed)
- Verified end-to-end that a generated table now emits `<w:tblW w:type="dxa" w:w="9746"/>`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-560a9325-e743-4d45-99f9-0f3bcc24f291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-560a9325-e743-4d45-99f9-0f3bcc24f291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tables now dynamically calculate and respect section-specific page configurations (size and margins) when rendering to DOCX, ensuring proper layout consistency across different page settings.

* **Tests**
  * Added comprehensive tests validating table width rendering behavior and page configuration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->