### PR TITLE
fix: render nested images and blockquote content

### DIFF
--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -91,7 +91,9 @@ export function mdastToDocxModel(
     };
   }
 
-  function processParagraph(paragraph: Paragraph): DocxBlockNode {
+  function processParagraph(
+    paragraph: Paragraph,
+  ): DocxBlockNode | DocxBlockNode[] {
     // If the paragraph consists of a single image, treat it as a block image
     if (
       paragraph.children.length === 1 &&
@@ -103,6 +105,40 @@ export function mdastToDocxModel(
         alt: img.alt || "",
         url: img.url || "",
       };
+    }
+
+    if (paragraph.children.some((child) => (child as any).type === "image")) {
+      const blocks: DocxBlockNode[] = [];
+      let inlineBuffer: typeof paragraph.children = [];
+
+      const flushInlineBuffer = (): void => {
+        if (inlineBuffer.length === 0) {
+          return;
+        }
+
+        blocks.push({
+          type: "paragraph",
+          children: processInlineNodes(inlineBuffer),
+        });
+        inlineBuffer = [];
+      };
+
+      for (const child of paragraph.children) {
+        if ((child as any).type === "image") {
+          flushInlineBuffer();
+          const image = child as Image;
+          blocks.push({
+            type: "image",
+            alt: image.alt || "",
+            url: image.url || "",
+          });
+        } else {
+          inlineBuffer.push(child);
+        }
+      }
+
+      flushInlineBuffer();
+      return blocks;
     }
 
     // Regular paragraph with inline content
@@ -133,7 +169,12 @@ export function mdastToDocxModel(
             itemChildren.push(nestedList);
           }
         } else if (child.type === "paragraph") {
-          itemChildren.push(processParagraph(child as Paragraph));
+          const processedParagraph = processParagraph(child as Paragraph);
+          if (Array.isArray(processedParagraph)) {
+            itemChildren.push(...processedParagraph);
+          } else {
+            itemChildren.push(processedParagraph);
+          }
         } else {
           // Other block content (headings, code blocks, etc.)
           const processed = processNode(child);
@@ -269,7 +310,7 @@ export function mdastToDocxModel(
         case "text":
           pushTextWithUnderline((node as Text).value);
           break;
-        case "emphasis":
+        case "emphasis": {
           const emphasisChildren = processInlineNodes(
             (node as Emphasis).children,
           );
@@ -280,7 +321,8 @@ export function mdastToDocxModel(
             });
           }
           break;
-        case "strong":
+        }
+        case "strong": {
           const strongChildren = processInlineNodes((node as Strong).children);
           for (const child of strongChildren) {
             result.push({
@@ -289,7 +331,8 @@ export function mdastToDocxModel(
             });
           }
           break;
-        case "delete":
+        }
+        case "delete": {
           const strikeChildren = processInlineNodes((node as Delete).children);
           for (const child of strikeChildren) {
             result.push({
@@ -298,6 +341,7 @@ export function mdastToDocxModel(
             });
           }
           break;
+        }
         case "inlineCode":
           result.push({
             type: "text",

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -1,5 +1,28 @@
-import type { Root, Node, List, Heading, Paragraph, Code, Blockquote, Image, Table, TableRow, TableCell, Text, Emphasis, Strong, InlineCode, Link, Delete } from "mdast";
-import type { DocxDocumentModel, DocxBlockNode, DocxTextNode, DocxListItemNode } from "./docxModel.js";
+import type {
+  Root,
+  Node,
+  List,
+  Heading,
+  Paragraph,
+  Code,
+  Blockquote,
+  Image,
+  Table,
+  TableRow,
+  TableCell,
+  Text,
+  Emphasis,
+  Strong,
+  InlineCode,
+  Link,
+  Delete,
+} from "mdast";
+import type {
+  DocxDocumentModel,
+  DocxBlockNode,
+  DocxTextNode,
+  DocxListItemNode,
+} from "./docxModel.js";
 import { Style, Options } from "./types.js";
 
 /**
@@ -24,7 +47,11 @@ function classifyHtmlNode(value: string): DocxBlockNode | null {
  * Converts mdast AST to internal docx-friendly model
  * Handles nested lists properly using AST structure
  */
-export function mdastToDocxModel(root: Root, _style: Style, _options: Options): DocxDocumentModel {
+export function mdastToDocxModel(
+  root: Root,
+  _style: Style,
+  _options: Options,
+): DocxDocumentModel {
   const children: DocxBlockNode[] = [];
   let numberedListSequenceId = 0;
   const listSequenceMap = new Map<List, number>();
@@ -96,7 +123,7 @@ export function mdastToDocxModel(root: Root, _style: Style, _options: Options): 
     const listItems: DocxListItemNode[] = [];
     for (const item of list.children) {
       const itemChildren: DocxBlockNode[] = [];
-      
+
       // Process children of list item (ListItem.children is FlowContent[])
       for (const child of item.children) {
         if (child.type === "list") {
@@ -106,13 +133,7 @@ export function mdastToDocxModel(root: Root, _style: Style, _options: Options): 
             itemChildren.push(nestedList);
           }
         } else if (child.type === "paragraph") {
-          // Paragraph - convert to our paragraph model
-          const para = child as Paragraph;
-          const inlineChildren = processInlineNodes(para.children);
-          itemChildren.push({
-            type: "paragraph",
-            children: inlineChildren,
-          });
+          itemChildren.push(processParagraph(child as Paragraph));
         } else {
           // Other block content (headings, code blocks, etc.)
           const processed = processNode(child);
@@ -242,14 +263,16 @@ export function mdastToDocxModel(root: Root, _style: Style, _options: Options): 
         }
       }
     }
-    
+
     for (const node of nodes) {
       switch (node.type) {
         case "text":
           pushTextWithUnderline((node as Text).value);
           break;
         case "emphasis":
-          const emphasisChildren = processInlineNodes((node as Emphasis).children);
+          const emphasisChildren = processInlineNodes(
+            (node as Emphasis).children,
+          );
           for (const child of emphasisChildren) {
             result.push({
               ...child,
@@ -319,7 +342,7 @@ export function mdastToDocxModel(root: Root, _style: Style, _options: Options): 
           }
       }
     }
-    
+
     return result;
   }
 
@@ -343,10 +366,12 @@ export function mdastToDocxModel(root: Root, _style: Style, _options: Options): 
         continue;
       }
     }
-    
+
     // Handle HTML comments and page-break markers.
     if (child.type === "html") {
-      const classified = classifyHtmlNode((child as { value?: string }).value || "");
+      const classified = classifyHtmlNode(
+        (child as { value?: string }).value || "",
+      );
       if (classified) {
         children.push(classified);
       }

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -10,11 +10,17 @@ import {
   TableLayoutType,
   WidthType,
 } from "docx";
-import type { DocxDocumentModel, DocxBlockNode, DocxListNode, DocxListItemNode, DocxTextNode } from "./docxModel.js";
+import type {
+  DocxDocumentModel,
+  DocxBlockNode,
+  DocxListNode,
+  DocxListItemNode,
+  DocxTextNode,
+} from "./docxModel.js";
 import { Style, Options } from "./types.js";
 import { processHeading } from "./renderers/headingRenderer.js";
 import { processCodeBlock } from "./renderers/codeRenderer.js";
-import { processBlockquote } from "./renderers/blockquoteRenderer.js";
+import { blockquoteParagraphStyle } from "./renderers/blockquoteRenderer.js";
 import { processComment } from "./renderers/commentRenderer.js";
 import {
   processImage,
@@ -29,6 +35,10 @@ interface InlineOverrides {
   forceBold?: boolean;
   forceItalic?: boolean;
   size?: number;
+}
+
+interface RenderContext {
+  quoteLevel?: number;
 }
 
 /**
@@ -52,7 +62,7 @@ export async function modelToDocx(
      * avoiding the percentage form that Word 2007 treats as corrupt.
      */
     tableWidthTwips?: number;
-  } = {}
+  } = {},
 ): Promise<{
   children: (Paragraph | Table)[];
   headings: { text: string; level: number; bookmarkId: string }[];
@@ -78,7 +88,7 @@ export async function modelToDocx(
 
   function textRunFromNode(
     node: DocxTextNode,
-    overrides: InlineOverrides = {}
+    overrides: InlineOverrides = {},
   ): TextRun {
     if (node.code) {
       return processInlineCode(node.value, style, { size: overrides.size });
@@ -99,7 +109,7 @@ export async function modelToDocx(
 
   function renderInlineNodes(
     nodes: DocxTextNode[],
-    overrides: InlineOverrides = {}
+    overrides: InlineOverrides = {},
   ): (TextRun | ExternalHyperlink)[] {
     const out: (TextRun | ExternalHyperlink)[] = [];
     for (const node of nodes) {
@@ -120,7 +130,7 @@ export async function modelToDocx(
               }),
             ],
             link: node.link,
-          })
+          }),
         );
       } else {
         out.push(textRunFromNode(node, overrides));
@@ -133,12 +143,19 @@ export async function modelToDocx(
     return out;
   }
 
-  function paragraphFromInlineNodes(nodes: DocxTextNode[]): Paragraph {
+  function paragraphFromInlineNodes(
+    nodes: DocxTextNode[],
+    context: RenderContext = {},
+    overrides: InlineOverrides = {},
+  ): Paragraph {
     const alignment = style.paragraphAlignment
       ? AlignmentType[style.paragraphAlignment]
       : AlignmentType.LEFT;
+    const quoteStyle = context.quoteLevel
+      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      : undefined;
     return new Paragraph({
-      children: renderInlineNodes(nodes),
+      children: renderInlineNodes(nodes, overrides),
       spacing: {
         before: style.paragraphSpacing,
         after: style.paragraphSpacing,
@@ -150,14 +167,19 @@ export async function modelToDocx(
           ? { left: 0, right: 0 }
           : undefined,
       bidirectional: style.direction === "RTL",
+      ...quoteStyle,
     });
   }
 
-  function tableFromNode(node: Extract<DocxBlockNode, { type: "table" }>): Table {
+  function tableFromNode(
+    node: Extract<DocxBlockNode, { type: "table" }>,
+  ): Table {
     const layout =
-      style.tableLayout === "fixed" ? TableLayoutType.FIXED : TableLayoutType.AUTOFIT;
+      style.tableLayout === "fixed"
+        ? TableLayoutType.FIXED
+        : TableLayoutType.AUTOFIT;
     const getColumnAlignment = (
-      index: number
+      index: number,
     ): (typeof AlignmentType)[keyof typeof AlignmentType] => {
       const align = node.align?.[index];
       if (align === "center") return AlignmentType.CENTER;
@@ -183,7 +205,7 @@ export async function modelToDocx(
                 shading: {
                   fill: documentType === "report" ? "DDDDDD" : "F2F2F2",
                 },
-              })
+              }),
           ),
         }),
         ...node.rows.map(
@@ -198,9 +220,9 @@ export async function modelToDocx(
                         children: renderInlineNodes(cell),
                       }),
                     ],
-                  })
+                  }),
               ),
-            })
+            }),
         ),
       ],
       layout,
@@ -217,8 +239,12 @@ export async function modelToDocx(
     nodes: DocxTextNode[],
     isOrdered: boolean,
     level: number,
-    sequenceId: number | undefined
+    sequenceId: number | undefined,
+    context: RenderContext = {},
   ): Paragraph {
+    const quoteStyle = context.quoteLevel
+      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      : undefined;
     const base = {
       children: renderInlineNodes(nodes, { size: style.listItemSize || 24 }),
       spacing: {
@@ -226,6 +252,7 @@ export async function modelToDocx(
         after: style.paragraphSpacing / 2,
       },
       bidirectional: style.direction === "RTL",
+      ...quoteStyle,
     };
 
     if (isOrdered) {
@@ -244,10 +271,11 @@ export async function modelToDocx(
     });
   }
 
-  function renderBlockNode(
+  async function renderBlockNode(
     node: DocxBlockNode,
-    listLevel: number = 0
-  ): (Paragraph | Table)[] {
+    listLevel: number = 0,
+    context: RenderContext = {},
+  ): Promise<(Paragraph | Table)[]> {
     switch (node.type) {
       case "heading": {
         const headingText = node.children.map((c) => c.value).join("");
@@ -257,7 +285,7 @@ export async function modelToDocx(
           node.children,
           { level: node.level, bookmarkId },
           style,
-          (nodes, size) => renderInlineNodes(nodes, { size })
+          (nodes, size) => renderInlineNodes(nodes, { size }),
         );
         headings.push({
           text: headingText,
@@ -268,11 +296,11 @@ export async function modelToDocx(
       }
 
       case "paragraph": {
-        return [paragraphFromInlineNodes(node.children)];
+        return [paragraphFromInlineNodes(node.children, context)];
       }
 
       case "list": {
-        return renderList(node, listLevel || 0);
+        return renderList(node, listLevel || 0, context);
       }
 
       case "codeBlock": {
@@ -281,24 +309,17 @@ export async function modelToDocx(
             node.value,
             node.language,
             style,
-            options.codeHighlighting
+            options.codeHighlighting,
           ),
         ];
       }
 
       case "blockquote": {
-        return [
-          processBlockquote(node.children, style, (nodes) =>
-            renderInlineNodes(nodes, {
-              size: style.blockquoteSize || 24,
-              forceItalic: true,
-            })
-          ),
-        ];
+        return renderBlockquote(node, listLevel, context);
       }
 
       case "image": {
-        return [];
+        return renderImageNode(node);
       }
 
       case "table": {
@@ -306,7 +327,22 @@ export async function modelToDocx(
       }
 
       case "comment": {
-        return [processComment(node.value, style)];
+        if (!context.quoteLevel) {
+          return [processComment(node.value, style)];
+        }
+        return [
+          new Paragraph({
+            children: [
+              new TextRun({
+                text: `Comment: ${node.value}`,
+                italics: true,
+                color: "666666",
+                font: resolveFontFamily(style),
+              }),
+            ],
+            ...blockquoteParagraphStyle(style, context.quoteLevel),
+          }),
+        ];
       }
 
       case "pageBreak": {
@@ -324,10 +360,46 @@ export async function modelToDocx(
     }
   }
 
-  function renderList(
+  async function renderBlockquote(
+    node: Extract<DocxBlockNode, { type: "blockquote" }>,
+    listLevel: number,
+    context: RenderContext,
+  ): Promise<(Paragraph | Table)[]> {
+    const quoteContext = { quoteLevel: (context.quoteLevel || 0) + 1 };
+    const out: (Paragraph | Table)[] = [];
+
+    if (node.children.length === 0) {
+      out.push(
+        paragraphFromInlineNodes([], quoteContext, {
+          size: style.blockquoteSize || 24,
+          forceItalic: true,
+        }),
+      );
+      return out;
+    }
+
+    for (const child of node.children) {
+      if (child.type === "paragraph") {
+        out.push(
+          paragraphFromInlineNodes(child.children, quoteContext, {
+            size: style.blockquoteSize || 24,
+            forceItalic: true,
+          }),
+        );
+        continue;
+      }
+
+      out.push(...(await renderBlockNode(child, listLevel, quoteContext)));
+    }
+
+    return out;
+  }
+
+  async function renderList(
     list: DocxListNode,
-    currentLevel: number
-  ): Paragraph[] {
+    currentLevel: number,
+    context: RenderContext = {},
+  ): Promise<Paragraph[]> {
     const paragraphs: Paragraph[] = [];
     const adjustedSequenceId = list.sequenceId
       ? list.sequenceId + sequenceIdOffset
@@ -344,35 +416,47 @@ export async function modelToDocx(
         item,
         list.ordered,
         currentLevel,
-        adjustedSequenceId
+        adjustedSequenceId,
+        context,
       );
-      paragraphs.push(...itemParagraphs);
+      paragraphs.push(...(await itemParagraphs));
     }
 
     return paragraphs;
   }
 
-  function renderListItem(
+  async function renderListItem(
     item: DocxListItemNode,
     isOrdered: boolean,
     level: number,
-    sequenceId: number | undefined
-  ): Paragraph[] {
+    sequenceId: number | undefined,
+    context: RenderContext = {},
+  ): Promise<Paragraph[]> {
     const paragraphs: Paragraph[] = [];
 
     // Process children of list item
     for (const child of item.children) {
       if (child.type === "list") {
         // Nested list - render recursively
-        const nestedParagraphs = renderList(child as DocxListNode, level + 1);
+        const nestedParagraphs = await renderList(
+          child as DocxListNode,
+          level + 1,
+          context,
+        );
         paragraphs.push(...nestedParagraphs);
       } else if (child.type === "paragraph") {
         paragraphs.push(
-          listParagraphFromInlineNodes(child.children, isOrdered, level, sequenceId)
+          listParagraphFromInlineNodes(
+            child.children,
+            isOrdered,
+            level,
+            sequenceId,
+            context,
+          ),
         );
       } else {
         // Other block types - render normally but they'll appear as part of list item
-        const rendered = renderBlockNode(child, level);
+        const rendered = await renderBlockNode(child, level, context);
         // Filter out Tables - list items should only contain Paragraphs
         for (const item of rendered) {
           if (item instanceof Paragraph) {
@@ -385,7 +469,7 @@ export async function modelToDocx(
     // If no paragraphs were created, create an empty list item
     if (paragraphs.length === 0) {
       paragraphs.push(
-        listParagraphFromInlineNodes([], isOrdered, level, sequenceId)
+        listParagraphFromInlineNodes([], isOrdered, level, sequenceId, context),
       );
     }
 
@@ -406,38 +490,42 @@ export async function modelToDocx(
     });
   }
 
+  async function renderImageNode(
+    node: Extract<DocxBlockNode, { type: "image" }>,
+  ): Promise<Paragraph[]> {
+    if (processedImageCounter.count >= imageHandling.maxImages) {
+      return [imageCouldNotLoadParagraph(node.alt)];
+    }
+
+    try {
+      const { embedded, paragraphs } = await processImage(
+        node.alt,
+        node.url,
+        style,
+        imageHandling,
+      );
+      if (embedded) {
+        processedImageCounter.count++;
+      }
+      return paragraphs;
+    } catch {
+      return [imageCouldNotLoadParagraph(node.alt)];
+    }
+  }
+
   // Process all top-level nodes
   let previousNodeType: string | undefined;
   for (const node of model.children) {
     // Insert a blank spacer paragraph between back-to-back code blocks so
     // Word doesn't collapse the shared borders into a single visual block.
     if (node.type === "codeBlock" && previousNodeType === "codeBlock") {
-      children.push(new Paragraph({ children: [], spacing: { before: 0, after: 0 } }));
+      children.push(
+        new Paragraph({ children: [], spacing: { before: 0, after: 0 } }),
+      );
     }
 
-    if (node.type === "image") {
-      try {
-        if (processedImageCounter.count >= imageHandling.maxImages) {
-          children.push(imageCouldNotLoadParagraph(node.alt));
-        } else {
-          const { embedded, paragraphs } = await processImage(
-            node.alt,
-            node.url,
-            style,
-            imageHandling
-          );
-          children.push(...paragraphs);
-          if (embedded) {
-            processedImageCounter.count++;
-          }
-        }
-      } catch {
-        children.push(imageCouldNotLoadParagraph(node.alt));
-      }
-    } else {
-      const rendered = renderBlockNode(node);
-      children.push(...rendered);
-    }
+    const rendered = await renderBlockNode(node);
+    children.push(...rendered);
 
     previousNodeType = node.type;
   }

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -278,6 +278,29 @@ export async function modelToDocx(
     });
   }
 
+  function listContinuationParagraphFromInlineNodes(
+    nodes: DocxTextNode[],
+    level: number,
+    context: RenderContext = {},
+  ): Paragraph {
+    const quoteStyle = context.quoteLevel
+      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      : undefined;
+
+    return new Paragraph({
+      children: renderInlineNodes(nodes, { size: style.listItemSize || 24 }),
+      spacing: {
+        before: style.paragraphSpacing / 2,
+        after: style.paragraphSpacing / 2,
+      },
+      indent: {
+        left: 720 * (level + 1),
+      },
+      bidirectional: style.direction === "RTL",
+      ...quoteStyle,
+    });
+  }
+
   async function renderBlockNode(
     node: DocxBlockNode,
     listLevel: number = 0,
@@ -452,15 +475,25 @@ export async function modelToDocx(
         );
         paragraphs.push(...nestedParagraphs);
       } else if (child.type === "paragraph") {
-        paragraphs.push(
-          listParagraphFromInlineNodes(
-            child.children,
-            isOrdered,
-            level,
-            sequenceId,
-            context,
-          ),
-        );
+        if (paragraphs.length === 0) {
+          paragraphs.push(
+            listParagraphFromInlineNodes(
+              child.children,
+              isOrdered,
+              level,
+              sequenceId,
+              context,
+            ),
+          );
+        } else {
+          paragraphs.push(
+            listContinuationParagraphFromInlineNodes(
+              child.children,
+              level,
+              context,
+            ),
+          );
+        }
       } else {
         // Other block types - render normally but they'll appear as part of list item
         const markerContext =

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -10,6 +10,7 @@ import {
   TableLayoutType,
   WidthType,
 } from "docx";
+import type { IParagraphOptions } from "docx";
 import type {
   DocxDocumentModel,
   DocxBlockNode,
@@ -39,6 +40,12 @@ interface InlineOverrides {
 
 interface RenderContext {
   quoteLevel?: number;
+}
+
+interface ListMarkerContext {
+  isOrdered: boolean;
+  level: number;
+  sequenceId: number | undefined;
 }
 
 /**
@@ -319,7 +326,7 @@ export async function modelToDocx(
       }
 
       case "image": {
-        return renderImageNode(node);
+        return renderImageNode(node, context);
       }
 
       case "table": {
@@ -456,7 +463,16 @@ export async function modelToDocx(
         );
       } else {
         // Other block types - render normally but they'll appear as part of list item
-        const rendered = await renderBlockNode(child, level, context);
+        const markerContext =
+          child.type === "image" && paragraphs.length === 0
+            ? { isOrdered, level, sequenceId }
+            : undefined;
+        const rendered = await renderBlockNodeWithListMarker(
+          child,
+          level,
+          context,
+          markerContext,
+        );
         // Filter out Tables - list items should only contain Paragraphs
         for (const item of rendered) {
           if (item instanceof Paragraph) {
@@ -476,8 +492,58 @@ export async function modelToDocx(
     return paragraphs;
   }
 
-  function imageCouldNotLoadParagraph(alt: string): Paragraph {
+  function imageParagraphOptions(
+    context: RenderContext = {},
+    listMarker?: ListMarkerContext,
+  ): Partial<IParagraphOptions> {
+    let options: Partial<IParagraphOptions> = {};
+
+    if (context.quoteLevel) {
+      options = {
+        ...options,
+        ...blockquoteParagraphStyle(style, context.quoteLevel),
+      };
+    }
+
+    if (listMarker) {
+      if (listMarker.isOrdered) {
+        options = {
+          ...options,
+          numbering: {
+            reference: `numbered-list-${listMarker.sequenceId || 1}`,
+            level: listMarker.level,
+          },
+        };
+      } else {
+        options = {
+          ...options,
+          bullet: { level: listMarker.level },
+        };
+      }
+    }
+
+    return options;
+  }
+
+  async function renderBlockNodeWithListMarker(
+    node: DocxBlockNode,
+    listLevel: number,
+    context: RenderContext,
+    listMarker?: ListMarkerContext,
+  ): Promise<(Paragraph | Table)[]> {
+    if (node.type === "image") {
+      return renderImageNode(node, context, listMarker);
+    }
+
+    return renderBlockNode(node, listLevel, context);
+  }
+
+  function imageCouldNotLoadParagraph(
+    alt: string,
+    paragraphOptions: Partial<IParagraphOptions> = {},
+  ): Paragraph {
     return new Paragraph({
+      ...paragraphOptions,
       children: [
         new TextRun({
           text: `[Image could not be loaded: ${alt}]`,
@@ -492,9 +558,13 @@ export async function modelToDocx(
 
   async function renderImageNode(
     node: Extract<DocxBlockNode, { type: "image" }>,
+    context: RenderContext = {},
+    listMarker?: ListMarkerContext,
   ): Promise<Paragraph[]> {
+    const paragraphOptions = imageParagraphOptions(context, listMarker);
+
     if (processedImageCounter.count >= imageHandling.maxImages) {
-      return [imageCouldNotLoadParagraph(node.alt)];
+      return [imageCouldNotLoadParagraph(node.alt, paragraphOptions)];
     }
 
     try {
@@ -503,13 +573,14 @@ export async function modelToDocx(
         node.url,
         style,
         imageHandling,
+        paragraphOptions,
       );
       if (embedded) {
         processedImageCounter.count++;
       }
       return paragraphs;
     } catch {
-      return [imageCouldNotLoadParagraph(node.alt)];
+      return [imageCouldNotLoadParagraph(node.alt, paragraphOptions)];
     }
   }
 

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -396,7 +396,7 @@ export async function modelToDocx(
         continue;
       }
 
-      out.push(...(await renderBlockNode(child, listLevel, quoteContext)));
+      out.push(...(await renderBlockNode(child, 0, quoteContext)));
     }
 
     return out;
@@ -464,7 +464,7 @@ export async function modelToDocx(
       } else {
         // Other block types - render normally but they'll appear as part of list item
         const markerContext =
-          child.type === "image" && paragraphs.length === 0
+          paragraphs.length === 0
             ? { isOrdered, level, sequenceId }
             : undefined;
         const rendered = await renderBlockNodeWithListMarker(
@@ -533,6 +533,20 @@ export async function modelToDocx(
   ): Promise<(Paragraph | Table)[]> {
     if (node.type === "image") {
       return renderImageNode(node, context, listMarker);
+    }
+
+    if (listMarker) {
+      const rendered = await renderBlockNode(node, listLevel, context);
+      return [
+        listParagraphFromInlineNodes(
+          [],
+          listMarker.isOrdered,
+          listMarker.level,
+          listMarker.sequenceId,
+          context,
+        ),
+        ...rendered,
+      ];
     }
 
     return renderBlockNode(node, listLevel, context);

--- a/src/renderers/blockquoteRenderer.ts
+++ b/src/renderers/blockquoteRenderer.ts
@@ -1,12 +1,5 @@
-import {
-  Paragraph,
-  TextRun,
-  ExternalHyperlink,
-  AlignmentType,
-  BorderStyle,
-} from "docx";
+import { AlignmentType, BorderStyle } from "docx";
 import { Style } from "../types.js";
-import type { DocxBlockNode, DocxTextNode } from "../docxModel.js";
 
 const BLOCKQUOTE_ALIGNMENTS: Record<
   NonNullable<Style["blockquoteAlignment"]>,
@@ -18,47 +11,40 @@ const BLOCKQUOTE_ALIGNMENTS: Record<
   JUSTIFIED: AlignmentType.JUSTIFIED,
 };
 
+export interface BlockquoteParagraphStyle {
+  indent: {
+    left: number;
+  };
+  spacing: {
+    before: number;
+    after: number;
+  };
+  border: {
+    left: {
+      style: typeof BorderStyle.SINGLE;
+      size: number;
+      color: string;
+    };
+  };
+  alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
+  bidirectional: boolean;
+}
+
 /**
- * Builds a blockquote paragraph from its structured children, preserving
- * inline formatting, links, and code via the caller-supplied renderer
- * (which also applies the blockquote's italic + size styling). Multiple
- * child paragraphs are separated by a line break.
- *
- * @param children - The blockquote's block children (paragraphs)
- * @param style - The style configuration
- * @param renderInline - Renders inline nodes with blockquote run styling
- * @returns The processed paragraph
+ * Returns paragraph options shared by each rendered blockquote paragraph.
+ * Nested quotes increase the left indent while preserving the same border.
  */
-export function processBlockquote(
-  children: DocxBlockNode[],
+export function blockquoteParagraphStyle(
   style: Style,
-  renderInline: (nodes: DocxTextNode[]) => (TextRun | ExternalHyperlink)[]
-): Paragraph {
-  const runs: (TextRun | ExternalHyperlink)[] = [];
-  const paragraphs = children.filter(
-    (child): child is Extract<DocxBlockNode, { type: "paragraph" }> =>
-      child.type === "paragraph"
-  );
-
-  paragraphs.forEach((paragraph, index) => {
-    if (index > 0) {
-      runs.push(new TextRun({ break: 1, rightToLeft: style.direction === "RTL" }));
-    }
-    runs.push(...renderInline(paragraph.children));
-  });
-
-  if (runs.length === 0) {
-    runs.push(new TextRun({ text: "", italics: true }));
-  }
-
+  quoteLevel: number,
+): BlockquoteParagraphStyle {
   const alignment = style.blockquoteAlignment
     ? BLOCKQUOTE_ALIGNMENTS[style.blockquoteAlignment]
     : undefined;
 
-  return new Paragraph({
-    children: runs,
+  return {
     indent: {
-      left: 720,
+      left: 720 * Math.max(1, quoteLevel),
     },
     spacing: {
       before: style.paragraphSpacing,
@@ -73,5 +59,5 @@ export function processBlockquote(
     },
     alignment,
     bidirectional: style.direction === "RTL",
-  });
+  };
 }

--- a/src/renderers/imageRenderer.ts
+++ b/src/renderers/imageRenderer.ts
@@ -1,4 +1,5 @@
 import { Paragraph, TextRun, AlignmentType, ImageRun } from "docx";
+import type { IParagraphOptions } from "docx";
 import { ImageHandlingOptions, Style } from "../types.js";
 import { resolveFontFamily } from "../utils/styleUtils.js";
 import {
@@ -22,7 +23,7 @@ export function computeImageDimensions(
   widthHint: number | undefined,
   heightHint: number | undefined,
   intrinsicWidth: number | undefined,
-  intrinsicHeight: number | undefined
+  intrinsicHeight: number | undefined,
 ): { width: number; height?: number } {
   let outWidth: number;
   let outHeight: number | undefined;
@@ -66,7 +67,7 @@ function readUint32BE(buf: Uint8Array, offset: number): number {
 
 function readIntrinsicDimensions(
   imageType: "png" | "jpg" | "gif",
-  bytes: Uint8Array
+  bytes: Uint8Array,
 ): { width?: number; height?: number } {
   let width: number | undefined;
   let height: number | undefined;
@@ -105,7 +106,7 @@ function readIntrinsicDimensions(
 function detectImageType(
   bytes: Uint8Array,
   contentType: string,
-  imageUrl: string
+  imageUrl: string,
 ): "png" | "jpg" | "gif" {
   const isPng =
     bytes.length >= 8 &&
@@ -142,7 +143,7 @@ function detectImageType(
   if (isGif) return "gif";
 
   throw new Error(
-    `Unsupported or invalid image data (${contentType || imageUrl})`
+    `Unsupported or invalid image data (${contentType || imageUrl})`,
   );
 }
 
@@ -159,7 +160,8 @@ export async function processImage(
   altText: string,
   imageUrl: string,
   style: Style,
-  imageHandling?: ImageHandlingOptions
+  imageHandling?: ImageHandlingOptions,
+  paragraphOptions: Partial<IParagraphOptions> = {},
 ): Promise<ProcessImageResult> {
   try {
     const resolvedImageHandling = resolveImageHandlingOptions(imageHandling);
@@ -195,7 +197,9 @@ export async function processImage(
       }
       const match = urlWithoutFragment.match(/^data:([^;,]*)(;base64)?,(.*)$/i);
       if (!match) {
-        throw new Error(`Invalid data URL for image: ${urlWithoutFragment.substring(0, 100)}...`);
+        throw new Error(
+          `Invalid data URL for image: ${urlWithoutFragment.substring(0, 100)}...`,
+        );
       }
       contentType = match[1] || "";
       const isBase64 = !!match[2];
@@ -213,8 +217,8 @@ export async function processImage(
             ? Buffer.from(dataPart, "base64")
             : Uint8Array.from(atob(dataPart), (c) => c.charCodeAt(0))
           : typeof Buffer !== "undefined"
-          ? Buffer.from(decodeURIComponent(dataPart))
-          : new TextEncoder().encode(decodeURIComponent(dataPart));
+            ? Buffer.from(decodeURIComponent(dataPart))
+            : new TextEncoder().encode(decodeURIComponent(dataPart));
         data = binary as Uint8Array | Buffer;
 
         if (!data || data.length === 0) {
@@ -224,12 +228,14 @@ export async function processImage(
           throw new Error("Data URL image exceeds maximum size");
         }
       } catch (error) {
-        throw new Error(`Failed to decode data URL: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(
+          `Failed to decode data URL: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     } else {
       const remoteImage = await fetchRemoteImage(
         urlWithoutFragment,
-        resolvedImageHandling
+        resolvedImageHandling,
       );
       data =
         typeof Buffer !== "undefined"
@@ -240,37 +246,40 @@ export async function processImage(
     }
 
     if (!data || data.length === 0) {
-      throw new Error(`Invalid image data: data length is ${data ? (data instanceof Uint8Array ? data.length : (data as Buffer).length) : 0}`);
+      throw new Error(
+        `Invalid image data: data length is ${data ? (data instanceof Uint8Array ? data.length : (data as Buffer).length) : 0}`,
+      );
     }
 
     const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
     const imageType = detectImageType(bytes, contentType, urlForTypeDetection);
-    const { width: intrinsicWidth, height: intrinsicHeight } = readIntrinsicDimensions(
-      imageType,
-      bytes
-    );
+    const { width: intrinsicWidth, height: intrinsicHeight } =
+      readIntrinsicDimensions(imageType, bytes);
 
     const { width: outWidth, height: outHeight } = computeImageDimensions(
       widthHint,
       heightHint,
       intrinsicWidth,
-      intrinsicHeight
+      intrinsicHeight,
     );
 
     // docx expects Buffer in Node.js, Uint8Array in browsers
-    const imageData = typeof Buffer !== "undefined" && !(data instanceof Buffer)
-      ? Buffer.from(data)
-      : data instanceof Uint8Array
-      ? data
-      : Buffer.from(data as Uint8Array);
+    const imageData =
+      typeof Buffer !== "undefined" && !(data instanceof Buffer)
+        ? Buffer.from(data)
+        : data instanceof Uint8Array
+          ? data
+          : Buffer.from(data as Uint8Array);
 
     // Fallback height if neither hints nor intrinsic dimensions provided one
-    const finalHeight = outHeight || (outWidth ? Math.round(outWidth * 0.75) : 200);
+    const finalHeight =
+      outHeight || (outWidth ? Math.round(outWidth * 0.75) : 200);
 
     return {
       embedded: true,
       paragraphs: [
         new Paragraph({
+          ...paragraphOptions,
           children: [
             new ImageRun({
               data: imageData,
@@ -294,6 +303,7 @@ export async function processImage(
       embedded: false,
       paragraphs: [
         new Paragraph({
+          ...paragraphOptions,
           children: [
             new TextRun({
               text: `[Image could not be displayed: ${altText}]`,

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -25,6 +25,10 @@ function numberingLevels(xml: string): string[] {
   );
 }
 
+function numberingMarkerCount(xml: string): number {
+  return xml.match(/<w:numPr>/g)?.length || 0;
+}
+
 async function render(markdown: string, options?: Options): Promise<string> {
   const blob = await convertMarkdownToDocx(markdown, options);
   expect(blob).toBeInstanceOf(Blob);
@@ -257,6 +261,15 @@ Interrupting paragraph.
 
     expect(xml).toContain("<w:numPr>");
     expect(xml).toContain("quoted block");
+  });
+
+  it("does not duplicate markers for split list item content", async () => {
+    const xml = await render(`- Before ![mixed image](${ONE_PX_PNG}) after`);
+
+    expect(xml).toContain("Before ");
+    expect(xml).toContain(" after");
+    expect(xml).toContain("<w:drawing>");
+    expect(numberingMarkerCount(xml)).toBe(1);
   });
 });
 

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -16,6 +16,15 @@ function documentParagraphCount(xml: string): number {
   return xml.match(/<w:p>/g)?.length || 0;
 }
 
+function numberingLevels(xml: string): string[] {
+  return Array.from(
+    xml.matchAll(
+      /<w:numPr>[\s\S]*?<w:ilvl w:val="(\d+)"\/>[\s\S]*?<\/w:numPr>/g,
+    ),
+    (match) => match[1],
+  );
+}
+
 async function render(markdown: string, options?: Options): Promise<string> {
   const blob = await convertMarkdownToDocx(markdown, options);
   expect(blob).toBeInstanceOf(Blob);
@@ -169,6 +178,15 @@ Another paragraph with justified alignment.`;
     expect(xml).toContain("Inner quote");
     expect(documentParagraphCount(xml)).toBeGreaterThanOrEqual(2);
   });
+
+  it("starts quoted lists at quote-local list depth", async () => {
+    const xml = await render(`- outer
+  - > - quoted item`);
+
+    expect(xml).toContain("outer");
+    expect(xml).toContain("quoted item");
+    expect(numberingLevels(xml)).toEqual(["0", "1", "0"]);
+  });
 });
 
 describe("Rendering: inline formatting", () => {
@@ -232,6 +250,13 @@ Interrupting paragraph.
     expect(numberingXml).toBeDefined();
     expect(documentXml).toContain("First bullet");
     expect(documentXml).toContain("Should restart");
+  });
+
+  it("preserves a marker when the first list item child is a block", async () => {
+    const xml = await render(`- > quoted block`);
+
+    expect(xml).toContain("<w:numPr>");
+    expect(xml).toContain("quoted block");
   });
 });
 
@@ -408,6 +433,22 @@ describe("Rendering: images", () => {
     expect(documentXml).toContain("<w:drawing>");
     expect(documentXml).toContain("<w:pBdr>");
     expect(documentXml).toContain("<w:ind");
+    expect(mediaFiles.length).toBeGreaterThan(0);
+  });
+
+  it("preserves images mixed with paragraph text", async () => {
+    const markdown = `Before ![mixed image](${ONE_PX_PNG}) after`;
+
+    const blob = await convertMarkdownToDocx(markdown);
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const mediaFiles = Object.keys(zip.files).filter((p) =>
+      p.startsWith("word/media/"),
+    );
+
+    expect(documentXml).toContain("Before ");
+    expect(documentXml).toContain(" after");
+    expect(documentXml).toContain("<w:drawing>");
     expect(mediaFiles.length).toBeGreaterThan(0);
   });
 

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -391,6 +391,7 @@ describe("Rendering: images", () => {
     );
 
     expect(documentXml).toContain("<w:drawing>");
+    expect(documentXml).toContain("<w:numPr>");
     expect(mediaFiles.length).toBeGreaterThan(0);
   });
 
@@ -405,6 +406,8 @@ describe("Rendering: images", () => {
     );
 
     expect(documentXml).toContain("<w:drawing>");
+    expect(documentXml).toContain("<w:pBdr>");
+    expect(documentXml).toContain("<w:ind");
     expect(mediaFiles.length).toBeGreaterThan(0);
   });
 

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -12,11 +12,15 @@ import { getDocumentXml, getZip, saveBlobForDebug } from "./helpers";
 const ONE_PX_PNG =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAGgwJ/vk9yBgAAAABJRU5ErkJggg==";
 
+function documentParagraphCount(xml: string): number {
+  return xml.match(/<w:p>/g)?.length || 0;
+}
+
 async function render(markdown: string, options?: Options): Promise<string> {
   const blob = await convertMarkdownToDocx(markdown, options);
   expect(blob).toBeInstanceOf(Blob);
   expect(blob.type).toBe(
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   );
   return getDocumentXml(blob);
 }
@@ -61,7 +65,7 @@ describe("Rendering: headings and alignment", () => {
 
   it("renders heading inline formatting, links, and code from the model", async () => {
     const blob = await convertMarkdownToDocx(
-      "# Head **bold** and [lnk](https://example.com/h) and `code`"
+      "# Head **bold** and [lnk](https://example.com/h) and `code`",
     );
     const xml = await getDocumentXml(blob);
     const rels = await (await getZip(blob))
@@ -82,15 +86,12 @@ describe("Rendering: headings and alignment", () => {
 
   it("generates deterministic unique bookmark names across sections", async () => {
     const blob = await convertMarkdownToDocx("", {
-      sections: [
-        { markdown: "# Repeat" },
-        { markdown: "# Repeat" },
-      ],
+      sections: [{ markdown: "# Repeat" }, { markdown: "# Repeat" }],
     });
     const xml = await getDocumentXml(blob);
     const bookmarkNames = Array.from(
       xml.matchAll(/<w:bookmarkStart[^>]+w:name="([^"]+)"/g),
-      (match) => match[1]
+      (match) => match[1],
     );
 
     expect(bookmarkNames).toContain("_Toc_Repeat_1");
@@ -119,7 +120,7 @@ Another paragraph with justified alignment.`;
 
   it("preserves inline formatting, links, and code inside blockquotes", async () => {
     const blob = await convertMarkdownToDocx(
-      "> Quote with **bold**, [lnk](https://example.com/q) and `code`."
+      "> Quote with **bold**, [lnk](https://example.com/q) and `code`.",
     );
     const xml = await getDocumentXml(blob);
     const rels = await (await getZip(blob))
@@ -135,16 +136,38 @@ Another paragraph with justified alignment.`;
     expect(xml).not.toContain("`code`");
   });
 
-  it("separates multi-paragraph blockquotes with a line break", async () => {
+  it("renders multi-paragraph blockquotes as separate quoted paragraphs", async () => {
     const blob = await convertMarkdownToDocx(
-      "> First quoted paragraph.\n>\n> Second quoted paragraph."
+      "> First quoted paragraph.\n>\n> Second quoted paragraph.",
     );
     const xml = await getDocumentXml(blob);
 
     expect(xml).toContain("First quoted paragraph.");
     expect(xml).toContain("Second quoted paragraph.");
-    // The two child paragraphs are joined by an explicit break run.
-    expect(xml).toContain("<w:br/>");
+    expect(documentParagraphCount(xml)).toBeGreaterThanOrEqual(2);
+    expect(xml).not.toContain("<w:br/>");
+  });
+
+  it("renders lists inside blockquotes instead of dropping them", async () => {
+    const xml = await render(`> Quoted intro
+>
+> - list item 1
+> - list item 2`);
+
+    expect(xml).toContain("Quoted intro");
+    expect(xml).toContain("list item 1");
+    expect(xml).toContain("list item 2");
+    expect(xml).toContain("<w:numPr>");
+  });
+
+  it("renders nested blockquotes with all nested text preserved", async () => {
+    const xml = await render(`> Outer quote
+>
+> > Inner quote`);
+
+    expect(xml).toContain("Outer quote");
+    expect(xml).toContain("Inner quote");
+    expect(documentParagraphCount(xml)).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -202,9 +225,7 @@ Interrupting paragraph.
     await saveBlobForDebug(blob, "lists.docx");
     const zip = await getZip(blob);
     const documentXml = await zip.file("word/document.xml")!.async("string");
-    const numberingXml = await zip
-      .file("word/numbering.xml")
-      ?.async("string");
+    const numberingXml = await zip.file("word/numbering.xml")?.async("string");
 
     expect(documentXml).toContain("<w:numPr>");
     expect(documentXml).toMatch(/<w:numId\s+w:val="\d+"\s*\/>/);
@@ -354,9 +375,65 @@ describe("Rendering: images", () => {
 
     // docx should create a media entry for the embedded image
     const mediaFiles = Object.keys(zip.files).filter((p) =>
-      p.startsWith("word/media/")
+      p.startsWith("word/media/"),
     );
     expect(mediaFiles.length).toBeGreaterThan(0);
+  });
+
+  it("embeds images inside list items", async () => {
+    const markdown = `- ![list image](${ONE_PX_PNG})`;
+
+    const blob = await convertMarkdownToDocx(markdown);
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const mediaFiles = Object.keys(zip.files).filter((p) =>
+      p.startsWith("word/media/"),
+    );
+
+    expect(documentXml).toContain("<w:drawing>");
+    expect(mediaFiles.length).toBeGreaterThan(0);
+  });
+
+  it("embeds images inside blockquotes", async () => {
+    const markdown = `> ![quoted image](${ONE_PX_PNG})`;
+
+    const blob = await convertMarkdownToDocx(markdown);
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const mediaFiles = Object.keys(zip.files).filter((p) =>
+      p.startsWith("word/media/"),
+    );
+
+    expect(documentXml).toContain("<w:drawing>");
+    expect(mediaFiles.length).toBeGreaterThan(0);
+  });
+
+  it("applies maximum image count across top-level and nested images", async () => {
+    const markdown = `![one](${ONE_PX_PNG})
+
+- ![two](${ONE_PX_PNG})
+
+> ![three](${ONE_PX_PNG})`;
+
+    const blob = await convertMarkdownToDocx(markdown, {
+      imageHandling: { maxImages: 2 },
+    });
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const mediaFiles = Object.keys(zip.files).filter((p) =>
+      p.startsWith("word/media/"),
+    );
+
+    expect(documentXml.match(/<w:drawing>/g)).toHaveLength(2);
+    expect(mediaFiles).toHaveLength(2);
+    expect(documentXml).toContain("Image could not be loaded");
+  });
+
+  it("renders a fallback for invalid nested images", async () => {
+    const xml = await render(`> ![broken](not-a-url)`);
+
+    expect(xml).toContain("Image could not be displayed");
+    expect(xml).toContain("broken");
   });
 });
 
@@ -407,10 +484,10 @@ More content.`;
     expect(xml).toContain("Hidden H1");
     expect(xml).toContain("Hidden H4");
     expect(xml.indexOf(">Included H2<")).toBeLessThan(
-      xml.lastIndexOf(">Included H2<")
+      xml.lastIndexOf(">Included H2<"),
     );
     expect(xml.indexOf(">Included H3<")).toBeLessThan(
-      xml.lastIndexOf(">Included H3<")
+      xml.lastIndexOf(">Included H3<"),
     );
     expect(xml.indexOf(">Hidden H1<")).toBe(xml.lastIndexOf(">Hidden H1<"));
     expect(xml.indexOf(">Hidden H4<")).toBe(xml.lastIndexOf(">Hidden H4<"));
@@ -420,7 +497,9 @@ More content.`;
 describe("Rendering: Node output helpers", () => {
   it("returns valid DOCX bytes as Buffer and ArrayBuffer", async () => {
     const buffer = await convertMarkdownToBuffer("# Buffer helper");
-    const arrayBuffer = await convertMarkdownToArrayBuffer("# ArrayBuffer helper");
+    const arrayBuffer = await convertMarkdownToArrayBuffer(
+      "# ArrayBuffer helper",
+    );
 
     expect(Buffer.isBuffer(buffer)).toBe(true);
     expect(buffer.length).toBeGreaterThan(0);
@@ -457,13 +536,13 @@ describe("Rendering: error cases", () => {
     await expect(
       convertMarkdownToDocx("Hello", {
         style: { fontFamily: "   " },
-      })
+      }),
     ).rejects.toThrow("Invalid fontFamily");
   });
 
   it("throws MarkdownConversionError for non-string markdown input", async () => {
     await expect(
-      convertMarkdownToDocx(undefined as unknown as string)
+      convertMarkdownToDocx(undefined as unknown as string),
     ).rejects.toBeInstanceOf(MarkdownConversionError);
   });
 });


### PR DESCRIPTION
## Summary
- render images inside lists, blockquotes, and nested contexts instead of dropping them
- render blockquote children structurally so paragraphs, lists, nested quotes, and inline formatting are preserved
- add regressions for issues #30 and #36

Fixes #30
Fixes #36

## Verification
- npx prettier --write src/modelToDocx.ts src/mdastToDocxModel.ts src/renderers/blockquoteRenderer.ts tests/rendering.test.ts
- npm run build -- --pretty false
- npm run lint
- npm test -- --runInBand

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mdast→model→DOCX rendering paths (lists, blockquotes, images) with behavior changes for multi-paragraph quotes and image placement; mitigated by expanded rendering tests.
> 
> **Overview**
> Fixes **nested images and blockquote content** so Markdown→DOCX no longer drops or flattens complex structures.
> 
> **AST (`mdastToDocxModel`)**: Paragraphs that mix text and images are split into separate paragraph and image blocks; list items reuse that logic so images inside lists are modeled correctly.
> 
> **DOCX rendering (`modelToDocx`)**: Blockquotes are rendered **per child block** (separate quoted paragraphs, nested lists/quotes, etc.) via a `quoteLevel` context and shared `blockquoteParagraphStyle`, instead of one paragraph with line breaks. **Images** go through the same block renderer as other nodes, with optional list/quote paragraph options; `maxImages` applies across top-level and nested placements. List items whose first child is a non-paragraph block get an empty marker paragraph so bullets/numbers still appear.
> 
> **Supporting changes**: `processBlockquote` is removed in favor of style helpers; `processImage` merges caller `paragraphOptions` for quote/list styling. Tests cover blockquote lists/nesting, mixed inline images, list/blockquote images, and image limits/fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a08515bf3cc0f2f2f0136469cedd70bb84f9b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paragraphs that mix text and images now split into ordered text and image blocks so images and surrounding text render correctly.
  * Blockquotes: multi-paragraph and nested quotes render with proper styling and indentation; lists inside blockquotes preserve markers and nesting.
  * Image handling: clearer fallback messaging for failed images and enforcement of max-image limits across document contexts.

* **Tests**
  * Expanded tests for blockquote behavior, lists in quotes, image embedding, max-image limits, and fallback rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->