### PR TITLE
[codex] add opt-in processing limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A TypeScript-first library and CLI that turns Markdown into production-ready Wor
   - [Custom heading and paragraph alignment](#custom-heading-and-paragraph-alignment)
   - [Table of Contents styling](#table-of-contents-styling)
   - [Text find-and-replace](#text-find-and-replace)
+  - [Server-side processing limits](#server-side-processing-limits)
   - [RTL / bidirectional text](#rtl--bidirectional-text)
 - [Supported Markdown](#supported-markdown)
 - [API reference](#api-reference)
@@ -322,6 +323,31 @@ For untrusted input, prefer literal string replacements. Regex replacements are 
 
 Escaped link syntax such as `\[label](https://example.com)` stays plain text in the DOCX. Hyperlinks are emitted only from actual Markdown link nodes.
 
+### Server-side processing limits
+
+Limits are opt-in so existing large-document workflows keep working. For API endpoints, upload forms, webhooks, or any untrusted input, set both input and parsed-structure caps and use `AbortSignal` for request cancellation or timeouts:
+
+```typescript
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 10_000);
+
+try {
+  const blob = await convertMarkdownToDocx(markdown, {
+    maxInputLength: 1_048_576,
+    maxElements: 50_000,
+    signal: controller.signal,
+    imageHandling: {
+      remote: { enabled: false },
+      maxImages: 25,
+    },
+  });
+} finally {
+  clearTimeout(timeout);
+}
+```
+
+`maxInputLength` is measured with JavaScript string length. When `sections` is provided, all section markdown lengths are summed. `maxElements` counts parsed Markdown AST nodes across every section after `textReplacements` run. The CLI options JSON can set numeric limits, but `signal` is programmatic-only.
+
 ### RTL / bidirectional text
 
 ```typescript
@@ -387,10 +413,14 @@ interface Options {
   documentType?: "document" | "report";
   style?: Style;
   toc?: TocOptions;
+  maxInputLength?: number;
+  maxElements?: number;
+  signal?: AbortSignal;
   template?: DocumentSection;
   sections?: DocumentSection[];
   codeHighlighting?: CodeHighlightOptions;
   textReplacements?: TextReplacement[];
+  imageHandling?: ImageHandlingOptions;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   enforceElementLimit,
   enforceInputLength,
   throwIfAborted,
+  yieldToAbortSignal,
 } from "./processingLimits.js";
 
 const defaultStyle: Style = {
@@ -80,10 +81,10 @@ export async function convertMarkdownToDocx(
 ): Promise<Blob> {
   try {
     const docxOptions = await parseToDocxOptions(markdown, options);
-    throwIfAborted(options.signal);
+    await yieldToAbortSignal(options.signal);
     const doc = new Document(docxOptions);
     const blob = await Packer.toBlob(doc);
-    throwIfAborted(options.signal);
+    await yieldToAbortSignal(options.signal);
     return blob;
   } catch (error) {
     if (error instanceof MarkdownConversionError) {
@@ -147,8 +148,9 @@ export async function parseToDocxOptions(
 
     for (const section of resolvedSections) {
       throwIfAborted(options.signal);
+      await yieldToAbortSignal(options.signal);
       const ast = await parseMarkdownToAst(section.markdown);
-      throwIfAborted(options.signal);
+      await yieldToAbortSignal(options.signal);
 
       if (options.textReplacements && options.textReplacements.length > 0) {
         applyTextReplacements(ast, options.textReplacements);

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,8 +208,10 @@ export async function parseToDocxOptions(
       };
     });
 
+    throwIfAborted(options.signal);
     const numberingConfigs = [];
     for (let i = 1; i <= maxSequenceId; i++) {
+      throwIfAborted(options.signal);
       numberingConfigs.push({
         reference: `numbered-list-${i}`,
         levels: [
@@ -228,6 +230,7 @@ export async function parseToDocxOptions(
       });
     }
 
+    throwIfAborted(options.signal);
     return {
       numbering: {
         config: numberingConfigs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ import {
   TocHeadingEntry,
 } from "./tocBuilder.js";
 import { buildParagraphStyles } from "./documentStyles.js";
+import {
+  enforceElementLimit,
+  enforceInputLength,
+  throwIfAborted,
+} from "./processingLimits.js";
 
 const defaultStyle: Style = {
   titleSize: 32,
@@ -75,8 +80,11 @@ export async function convertMarkdownToDocx(
 ): Promise<Blob> {
   try {
     const docxOptions = await parseToDocxOptions(markdown, options);
+    throwIfAborted(options.signal);
     const doc = new Document(docxOptions);
-    return await Packer.toBlob(doc);
+    const blob = await Packer.toBlob(doc);
+    throwIfAborted(options.signal);
+    return blob;
   } catch (error) {
     if (error instanceof MarkdownConversionError) {
       throw error;
@@ -118,6 +126,8 @@ export async function parseToDocxOptions(
 ): Promise<IPropertiesOptions> {
   try {
     validateInput(markdown, options);
+    throwIfAborted(options.signal);
+    enforceInputLength(markdown, options);
 
     const normalizedStyle = normalizeStyleInput(options.style);
     const style: Style = { ...defaultStyle, ...normalizedStyle };
@@ -133,15 +143,26 @@ export async function parseToDocxOptions(
     const processedImageCounter = { count: 0 };
     const headingBookmarkCounter = { count: 0 };
     const tocPlaceholders = new WeakSet<object>();
+    let elementCount = 0;
 
     for (const section of resolvedSections) {
+      throwIfAborted(options.signal);
       const ast = await parseMarkdownToAst(section.markdown);
+      throwIfAborted(options.signal);
 
       if (options.textReplacements && options.textReplacements.length > 0) {
         applyTextReplacements(ast, options.textReplacements);
       }
+      throwIfAborted(options.signal);
+      elementCount = enforceElementLimit(
+        ast,
+        options.maxElements,
+        elementCount,
+        options.signal
+      );
 
       const model = mdastToDocxModel(ast, section.style, options);
+      throwIfAborted(options.signal);
       const renderedModel = await modelToDocx(model, section.style, options, {
         sequenceIdOffset: maxSequenceId,
         processedImageCounter,
@@ -163,9 +184,11 @@ export async function parseToDocxOptions(
       });
     }
 
+    throwIfAborted(options.signal);
     const tocContent = buildTocContent(headings, style, options.toc);
     let tocInserted = false;
     const docSections: ISectionOptions[] = renderedSections.map((section) => {
+      throwIfAborted(options.signal);
       const replacedTocChildren = replaceTocPlaceholders(
         section.children,
         tocContent,

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -31,6 +31,7 @@ import { processInlineCode } from "./renderers/textRenderer.js";
 import { resolveFontFamily } from "./utils/styleUtils.js";
 import { sanitizeForBookmarkId } from "./utils/bookmarkUtils.js";
 import { throwIfAborted } from "./processingLimits.js";
+import { MarkdownConversionError } from "./errors.js";
 
 /** Rendering overrides shared across inline-node renderers. */
 interface InlineOverrides {
@@ -646,7 +647,10 @@ export async function modelToDocx(
         processedImageCounter.count++;
       }
       return paragraphs;
-    } catch {
+    } catch (error) {
+      if (error instanceof MarkdownConversionError) {
+        throw error;
+      }
       return [imageCouldNotLoadParagraph(node.alt, paragraphOptions)];
     }
   }

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -30,6 +30,7 @@ import {
 import { processInlineCode } from "./renderers/textRenderer.js";
 import { resolveFontFamily } from "./utils/styleUtils.js";
 import { sanitizeForBookmarkId } from "./utils/bookmarkUtils.js";
+import { throwIfAborted } from "./processingLimits.js";
 
 /** Rendering overrides shared across inline-node renderers. */
 interface InlineOverrides {
@@ -92,6 +93,8 @@ export async function modelToDocx(
   const headingBookmarkCounter = renderOptions.headingBookmarkCounter ?? {
     count: 0,
   };
+
+  throwIfAborted(options.signal);
 
   function textRunFromNode(
     node: DocxTextNode,
@@ -306,6 +309,8 @@ export async function modelToDocx(
     listLevel: number = 0,
     context: RenderContext = {},
   ): Promise<(Paragraph | Table)[]> {
+    throwIfAborted(options.signal);
+
     switch (node.type) {
       case "heading": {
         const headingText = node.children.map((c) => c.value).join("");
@@ -395,6 +400,8 @@ export async function modelToDocx(
     listLevel: number,
     context: RenderContext,
   ): Promise<(Paragraph | Table)[]> {
+    throwIfAborted(options.signal);
+
     const quoteContext = { quoteLevel: (context.quoteLevel || 0) + 1 };
     const out: (Paragraph | Table)[] = [];
 
@@ -409,6 +416,8 @@ export async function modelToDocx(
     }
 
     for (const child of node.children) {
+      throwIfAborted(options.signal);
+
       if (child.type === "paragraph") {
         out.push(
           paragraphFromInlineNodes(child.children, quoteContext, {
@@ -430,6 +439,8 @@ export async function modelToDocx(
     currentLevel: number,
     context: RenderContext = {},
   ): Promise<Paragraph[]> {
+    throwIfAborted(options.signal);
+
     const paragraphs: Paragraph[] = [];
     const adjustedSequenceId = list.sequenceId
       ? list.sequenceId + sequenceIdOffset
@@ -441,6 +452,8 @@ export async function modelToDocx(
     }
 
     for (const item of list.children) {
+      throwIfAborted(options.signal);
+
       // Render list item content
       const itemParagraphs = renderListItem(
         item,
@@ -462,10 +475,14 @@ export async function modelToDocx(
     sequenceId: number | undefined,
     context: RenderContext = {},
   ): Promise<Paragraph[]> {
+    throwIfAborted(options.signal);
+
     const paragraphs: Paragraph[] = [];
 
     // Process children of list item
     for (const child of item.children) {
+      throwIfAborted(options.signal);
+
       if (child.type === "list") {
         // Nested list - render recursively
         const nestedParagraphs = await renderList(
@@ -608,6 +625,8 @@ export async function modelToDocx(
     context: RenderContext = {},
     listMarker?: ListMarkerContext,
   ): Promise<Paragraph[]> {
+    throwIfAborted(options.signal);
+
     const paragraphOptions = imageParagraphOptions(context, listMarker);
 
     if (processedImageCounter.count >= imageHandling.maxImages) {
@@ -621,6 +640,7 @@ export async function modelToDocx(
         style,
         imageHandling,
         paragraphOptions,
+        options.signal,
       );
       if (embedded) {
         processedImageCounter.count++;
@@ -634,6 +654,8 @@ export async function modelToDocx(
   // Process all top-level nodes
   let previousNodeType: string | undefined;
   for (const node of model.children) {
+    throwIfAborted(options.signal);
+
     // Insert a blank spacer paragraph between back-to-back code blocks so
     // Word doesn't collapse the shared borders into a single visual block.
     if (node.type === "codeBlock" && previousNodeType === "codeBlock") {

--- a/src/processingLimits.ts
+++ b/src/processingLimits.ts
@@ -12,6 +12,20 @@ export function throwIfAborted(signal: AbortSignal | undefined): void {
   });
 }
 
+export async function yieldToAbortSignal(
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    return;
+  }
+
+  throwIfAborted(signal);
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  throwIfAborted(signal);
+}
+
 export function enforceInputLength(markdown: string, options: Options): void {
   if (options.maxInputLength === undefined) {
     return;

--- a/src/processingLimits.ts
+++ b/src/processingLimits.ts
@@ -1,0 +1,76 @@
+import type { Root } from "mdast";
+import { MarkdownConversionError } from "./errors.js";
+import type { Options } from "./types.js";
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+
+  throw new MarkdownConversionError("Markdown conversion was aborted", {
+    reason: signal.reason,
+  });
+}
+
+export function enforceInputLength(markdown: string, options: Options): void {
+  if (options.maxInputLength === undefined) {
+    return;
+  }
+
+  const inputLength =
+    options.sections?.reduce((total, section) => {
+      return total + section.markdown.length;
+    }, 0) ?? markdown.length;
+
+  if (inputLength > options.maxInputLength) {
+    throw new MarkdownConversionError(
+      "Markdown input length exceeds maxInputLength",
+      {
+        inputLength,
+        maxInputLength: options.maxInputLength,
+      }
+    );
+  }
+}
+
+export function enforceElementLimit(
+  root: Root,
+  maxElements: number | undefined,
+  currentCount: number,
+  signal: AbortSignal | undefined
+): number {
+  if (maxElements === undefined) {
+    return currentCount;
+  }
+
+  const stack: unknown[] = [...root.children];
+  let elementCount = currentCount;
+
+  while (stack.length > 0) {
+    if (elementCount % 1000 === 0) {
+      throwIfAborted(signal);
+    }
+
+    const node = stack.pop();
+    elementCount++;
+
+    if (elementCount > maxElements) {
+      throw new MarkdownConversionError(
+        "Markdown element count exceeds maxElements",
+        {
+          elementCount,
+          maxElements,
+        }
+      );
+    }
+
+    const children = (node as { children?: unknown }).children;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        stack.push(child);
+      }
+    }
+  }
+
+  return elementCount;
+}

--- a/src/renderers/imageRenderer.ts
+++ b/src/renderers/imageRenderer.ts
@@ -6,6 +6,8 @@ import {
   fetchRemoteImage,
   resolveImageHandlingOptions,
 } from "../utils/secureImageFetch.js";
+import { MarkdownConversionError } from "../errors.js";
+import { throwIfAborted } from "../processingLimits.js";
 
 export {
   DEFAULT_IMAGE_HANDLING,
@@ -162,8 +164,10 @@ export async function processImage(
   style: Style,
   imageHandling?: ImageHandlingOptions,
   paragraphOptions: Partial<IParagraphOptions> = {},
+  signal?: AbortSignal,
 ): Promise<ProcessImageResult> {
   try {
+    throwIfAborted(signal);
     const resolvedImageHandling = resolveImageHandlingOptions(imageHandling);
     let widthHint: number | undefined;
     let heightHint: number | undefined;
@@ -192,6 +196,7 @@ export async function processImage(
     let urlForTypeDetection = imageUrl;
 
     if (/^data:/i.test(urlWithoutFragment)) {
+      throwIfAborted(signal);
       if (!resolvedImageHandling.dataUrls.enabled) {
         throw new Error("Data URL images are disabled");
       }
@@ -227,7 +232,11 @@ export async function processImage(
         if (data.length > resolvedImageHandling.maxImageBytes) {
           throw new Error("Data URL image exceeds maximum size");
         }
+        throwIfAborted(signal);
       } catch (error) {
+        if (error instanceof MarkdownConversionError) {
+          throw error;
+        }
         throw new Error(
           `Failed to decode data URL: ${error instanceof Error ? error.message : String(error)}`,
         );
@@ -236,6 +245,7 @@ export async function processImage(
       const remoteImage = await fetchRemoteImage(
         urlWithoutFragment,
         resolvedImageHandling,
+        signal,
       );
       data =
         typeof Buffer !== "undefined"
@@ -250,6 +260,7 @@ export async function processImage(
         `Invalid image data: data length is ${data ? (data instanceof Uint8Array ? data.length : (data as Buffer).length) : 0}`,
       );
     }
+    throwIfAborted(signal);
 
     const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
     const imageType = detectImageType(bytes, contentType, urlForTypeDetection);
@@ -298,7 +309,11 @@ export async function processImage(
         }),
       ],
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof MarkdownConversionError) {
+      throw error;
+    }
+
     return {
       embedded: false,
       paragraphs: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,22 @@ export interface Options {
   style?: Partial<Style>;
   toc?: TocOptions;
   /**
+   * Optional maximum markdown input length, measured with JavaScript string
+   * length. When `sections` is provided, all section markdown lengths are
+   * summed. Omitted by default, preserving unlimited input behavior.
+   */
+  maxInputLength?: number;
+  /**
+   * Optional maximum number of parsed markdown AST elements across the whole
+   * document. Omitted by default, preserving unlimited structure size.
+   */
+  maxElements?: number;
+  /**
+   * Optional cancellation signal for programmatic conversions. CLI JSON
+   * options cannot provide this value.
+   */
+  signal?: AbortSignal;
+  /**
    * Shared defaults applied to each section before per-section overrides.
    */
   template?: SectionTemplate;

--- a/src/utils/secureImageFetch.ts
+++ b/src/utils/secureImageFetch.ts
@@ -2,6 +2,7 @@ import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { Agent, buildConnector } from "undici";
 import { ImageHandlingOptions } from "../types.js";
+import { throwIfAborted } from "../processingLimits.js";
 
 export interface ResolvedImageHandlingOptions {
   remote: {
@@ -296,6 +297,53 @@ async function abortablePromise<T>(
   }
 }
 
+async function abortableCallerPromise<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  throwIfAborted(signal);
+
+  let onAbort!: () => void;
+  const abortPromise = new Promise<never>((_, reject) => {
+    onAbort = () => reject(abortErrorFromSignal(signal));
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } catch (error) {
+    if (signal.aborted) {
+      throwIfAborted(signal);
+    }
+    throw error;
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
+function linkCallerSignal(
+  controller: AbortController,
+  signal?: AbortSignal
+): () => void {
+  if (!signal) {
+    return () => {};
+  }
+  if (signal.aborted) {
+    controller.abort(signal.reason);
+    return () => {};
+  }
+
+  const onAbort = (): void => {
+    controller.abort(signal.reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  return () => signal.removeEventListener("abort", onAbort);
+}
+
 function abortErrorFromSignal(signal: AbortSignal): Error {
   const reason = signal.reason;
   if (reason instanceof Error) {
@@ -380,8 +428,11 @@ export interface RemoteImage {
  */
 export async function fetchRemoteImage(
   initialUrl: string,
-  options: ResolvedImageHandlingOptions
+  options: ResolvedImageHandlingOptions,
+  signal?: AbortSignal
 ): Promise<RemoteImage> {
+  throwIfAborted(signal);
+
   const totalBudgetMs = Math.max(1, options.fetchTimeoutMs);
   const deadline = Date.now() + totalBudgetMs;
   let currentUrl = new URL(initialUrl);
@@ -402,6 +453,8 @@ export async function fetchRemoteImage(
 
   try {
     while (true) {
+      throwIfAborted(signal);
+
       const remainMs = deadline - Date.now();
       if (remainMs <= 0) {
         throw new Error("Remote image fetch timed out");
@@ -413,10 +466,9 @@ export async function fetchRemoteImage(
       );
 
       await closePinned();
-      pinnedAgent = await preparePinnedAgentIfNeeded(
-        currentUrl,
-        options,
-        dnsBudgetMs
+      pinnedAgent = await abortableCallerPromise(
+        preparePinnedAgentIfNeeded(currentUrl, options, dnsBudgetMs),
+        signal
       );
 
       const hopRemainMs = deadline - Date.now();
@@ -425,9 +477,14 @@ export async function fetchRemoteImage(
       }
 
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), hopRemainMs);
+      const timeout = setTimeout(
+        () => controller.abort(new Error("Remote image fetch timed out")),
+        hopRemainMs
+      );
+      const unlinkCallerSignal = linkCallerSignal(controller, signal);
 
       try {
+        throwIfAborted(signal);
         const fetchInit: RequestInit & { dispatcher?: Agent } = {
           redirect: "manual",
           signal: controller.signal,
@@ -435,6 +492,7 @@ export async function fetchRemoteImage(
         };
 
         const response = await fetch(currentUrl.href, fetchInit);
+        throwIfAborted(signal);
 
         if (
           response.status >= 300 &&
@@ -464,6 +522,7 @@ export async function fetchRemoteImage(
           options.maxImageBytes,
           controller.signal
         );
+        throwIfAborted(signal);
 
         clearTimeout(timeout);
 
@@ -472,8 +531,14 @@ export async function fetchRemoteImage(
           contentType: response.headers.get("content-type") || "",
           finalUrl: currentUrl.href,
         };
+      } catch (error) {
+        if (signal?.aborted) {
+          throwIfAborted(signal);
+        }
+        throw error;
       } finally {
         clearTimeout(timeout);
+        unlinkCallerSignal();
       }
     }
   } finally {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -416,6 +416,22 @@ function validateImageHandlingInput(
   }
 }
 
+function validateProcessingLimitsInput(options: Options): void {
+  validatePositiveIntegerOption(options.maxInputLength, "maxInputLength");
+  validatePositiveIntegerOption(options.maxElements, "maxElements");
+
+  if (
+    options.signal !== undefined &&
+    (options.signal === null ||
+      typeof options.signal !== "object" ||
+      typeof options.signal.aborted !== "boolean" ||
+      typeof options.signal.addEventListener !== "function" ||
+      typeof options.signal.removeEventListener !== "function")
+  ) {
+    throw new MarkdownConversionError("Invalid signal: Must be an AbortSignal");
+  }
+}
+
 /**
  * Validates markdown input and options
  * @throws {MarkdownConversionError} If input is invalid
@@ -436,6 +452,7 @@ export function validateInput(markdown: string, options: Options): void {
   validateStyleInput(normalizeStyleInput(options.style), "options.style");
   validateTocOptionsInput(options.toc);
   validateImageHandlingInput(options.imageHandling);
+  validateProcessingLimitsInput(options);
 
   const normalizedTemplate = normalizeSectionConfig(options.template);
   if (normalizedTemplate) {

--- a/tests/processing-limits.test.ts
+++ b/tests/processing-limits.test.ts
@@ -4,7 +4,9 @@ import {
   MarkdownConversionError,
   parseToDocxOptions,
 } from "../src/index";
-import type { Options } from "../src/types";
+import { modelToDocx } from "../src/modelToDocx";
+import type { DocxDocumentModel } from "../src/docxModel";
+import type { Options, Style } from "../src/types";
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -19,6 +21,13 @@ const invalidLimitCases: Array<{
   { optionName: "maxElements", value: 0 },
   { optionName: "maxElements", value: Number.POSITIVE_INFINITY },
 ];
+
+const testStyle: Style = {
+  titleSize: 32,
+  headingSpacing: 240,
+  paragraphSpacing: 240,
+  lineSpacing: 1.15,
+};
 
 describe("Processing limits", () => {
   it("rejects oversized single markdown input when maxInputLength is set", async () => {
@@ -39,11 +48,11 @@ describe("Processing limits", () => {
   it.each(invalidLimitCases)(
     "rejects invalid $optionName values",
     async ({ optionName, value }) => {
-    await expect(
-      parseToDocxOptions("Valid input", {
-        [optionName]: value,
-      } as Options)
-    ).rejects.toBeInstanceOf(MarkdownConversionError);
+      await expect(
+        parseToDocxOptions("Valid input", {
+          [optionName]: value,
+        } as Options)
+      ).rejects.toBeInstanceOf(MarkdownConversionError);
     }
   );
 
@@ -107,5 +116,41 @@ describe("Conversion cancellation", () => {
     ).rejects.toThrow("Markdown conversion was aborted");
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows image aborts from model rendering", async () => {
+    const controller = new AbortController();
+    const model: DocxDocumentModel = {
+      children: [
+        {
+          type: "image",
+          alt: "remote",
+          url: "https://93.184.216.34/image.png",
+        },
+      ],
+    };
+
+    jest.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      setTimeout(() => {
+        controller.abort(new Error("caller cancelled"));
+      }, 0);
+
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        });
+      }) as never;
+    });
+
+    await expect(
+      modelToDocx(
+        model,
+        testStyle,
+        {
+          imageHandling: { remote: { enabled: true } },
+          signal: controller.signal,
+        },
+      )
+    ).rejects.toThrow("Markdown conversion was aborted");
   });
 });

--- a/tests/processing-limits.test.ts
+++ b/tests/processing-limits.test.ts
@@ -94,6 +94,17 @@ describe("Conversion cancellation", () => {
     ).rejects.toThrow("Markdown conversion was aborted");
   });
 
+  it("observes queued timeout aborts before markdown parsing continues", async () => {
+    const controller = new AbortController();
+    setTimeout(() => {
+      controller.abort(new Error("timeout"));
+    }, 0);
+
+    await expect(
+      parseToDocxOptions("# Timeout", { signal: controller.signal })
+    ).rejects.toThrow("Markdown conversion was aborted");
+  });
+
   it("rejects when the signal aborts during remote image fetch", async () => {
     const controller = new AbortController();
     jest.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {

--- a/tests/processing-limits.test.ts
+++ b/tests/processing-limits.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  convertMarkdownToDocx,
+  MarkdownConversionError,
+  parseToDocxOptions,
+} from "../src/index";
+import type { Options } from "../src/types";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const invalidLimitCases: Array<{
+  optionName: keyof Pick<Options, "maxInputLength" | "maxElements">;
+  value: number;
+}> = [
+  { optionName: "maxInputLength", value: 0 },
+  { optionName: "maxInputLength", value: 1.5 },
+  { optionName: "maxElements", value: 0 },
+  { optionName: "maxElements", value: Number.POSITIVE_INFINITY },
+];
+
+describe("Processing limits", () => {
+  it("rejects oversized single markdown input when maxInputLength is set", async () => {
+    await expect(
+      parseToDocxOptions("123456", { maxInputLength: 5 })
+    ).rejects.toThrow("Markdown input length exceeds maxInputLength");
+  });
+
+  it("rejects summed multi-section markdown input when maxInputLength is set", async () => {
+    await expect(
+      parseToDocxOptions("", {
+        maxInputLength: 5,
+        sections: [{ markdown: "123" }, { markdown: "456" }],
+      })
+    ).rejects.toThrow("Markdown input length exceeds maxInputLength");
+  });
+
+  it.each(invalidLimitCases)(
+    "rejects invalid $optionName values",
+    async ({ optionName, value }) => {
+    await expect(
+      parseToDocxOptions("Valid input", {
+        [optionName]: value,
+      } as Options)
+    ).rejects.toBeInstanceOf(MarkdownConversionError);
+    }
+  );
+
+  it("rejects invalid signal values", async () => {
+    await expect(
+      parseToDocxOptions("Valid input", {
+        signal: { aborted: false } as unknown as AbortSignal,
+      })
+    ).rejects.toThrow("Invalid signal");
+  });
+
+  it("rejects markdown that exceeds maxElements", async () => {
+    await expect(
+      parseToDocxOptions("Hello", { maxElements: 1 })
+    ).rejects.toThrow("Markdown element count exceeds maxElements");
+  });
+
+  it("applies maxElements across sections", async () => {
+    await expect(
+      parseToDocxOptions("", {
+        maxElements: 3,
+        sections: [{ markdown: "# One" }, { markdown: "# Two" }],
+      })
+    ).rejects.toThrow("Markdown element count exceeds maxElements");
+  });
+
+  it("does not apply input length or element limits by default", async () => {
+    await expect(parseToDocxOptions("a".repeat(1_048_577))).resolves.toBeDefined();
+  });
+});
+
+describe("Conversion cancellation", () => {
+  it("rejects when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("caller cancelled"));
+
+    await expect(
+      convertMarkdownToDocx("# Cancelled", { signal: controller.signal })
+    ).rejects.toThrow("Markdown conversion was aborted");
+  });
+
+  it("rejects when the signal aborts during remote image fetch", async () => {
+    const controller = new AbortController();
+    jest.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      setTimeout(() => {
+        controller.abort(new Error("caller cancelled"));
+      }, 0);
+
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        });
+      }) as never;
+    });
+
+    await expect(
+      convertMarkdownToDocx("![remote](https://93.184.216.34/image.png)", {
+        imageHandling: { remote: { enabled: true } },
+        signal: controller.signal,
+      })
+    ).rejects.toThrow("Markdown conversion was aborted");
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #38 by adding opt-in conversion guardrails for untrusted or server-side Markdown input.

- Adds `maxInputLength`, `maxElements`, and `signal` to `Options`
- Enforces input-length and parsed-element caps across single and multi-section conversions
- Adds cooperative cancellation checkpoints through parsing/rendering and remote image fetches
- Preserves existing unlimited behavior when limits are omitted
- Documents recommended server-side usage and adds regression coverage

## Validation

- `npm run build`
- `npm run lint`
- `npm test`

Note: `npm test` still prints the existing Watchman recrawl warning locally, but all 8 suites and 112 tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the core conversion path and remote image fetch behavior when limits or signals are set; defaults are unchanged, but abort errors now propagate from image rendering instead of degrading to placeholders.
> 
> **Overview**
> Adds **opt-in server-side guardrails** for Markdown→DOCX conversion so untrusted or API-driven workloads can cap work and cancel in flight without changing default behavior when limits are omitted.
> 
> **New `Options`:** `maxInputLength` (string length, summed across `sections`), `maxElements` (cumulative parsed AST nodes per document, after `textReplacements`), and programmatic-only `signal` (`AbortSignal`). Validation rejects non–positive integers and invalid signals.
> 
> **New `processingLimits` module** implements `enforceInputLength`, `enforceElementLimit` (with periodic abort checks every 1000 nodes), `throwIfAborted`, and `yieldToAbortSignal` (event-loop yield so queued aborts are observed).
> 
> **Pipeline integration:** `parseToDocxOptions` and `convertMarkdownToDocx` call these helpers at section boundaries, after parse, before/after packing, and throughout `modelToDocx` block/list/image rendering. **`MarkdownConversionError`** from abort/limit violations propagates from image handling instead of being swallowed as “image could not load.”
> 
> **Remote images:** `fetchRemoteImage` accepts the caller `signal`, links it to per-hop fetch timeouts, and races DNS prep and body reads so cancellation wins over slow fetches.
> 
> **Docs:** README section on recommended server usage (limits + timeout pattern + `imageHandling`). **Tests:** `processing-limits.test.ts` for limits, defaults, and cancellation during conversion and remote image fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a0ae6d708880ca9f54d0633fff90718c06d76b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server-side processing limits with `maxInputLength` and `maxElements` options to control input size and document complexity
  * Added `AbortSignal` support for conversion cancellation, enabling timeout-based aborts in programmatic usage

* **Documentation**
  * Updated README with processing limits configuration examples, timeout patterns, and image handling guidelines

* **Tests**
  * Added comprehensive test coverage for processing limits validation and conversion cancellation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->