### PR TITLE
fix: address security audit findings (links, images, comments, deps)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2876,9 +2876,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4338,9 +4338,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4348,9 +4348,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5814,9 +5814,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7287,9 +7287,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.16.0.tgz",
+      "integrity": "sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7368,8 +7368,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/config": "^10.10.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -7387,27 +7387,27 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.9",
+        "libnpmexec": "^10.2.9",
+        "libnpmfund": "^7.0.23",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.9",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -7422,11 +7422,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -7482,7 +7482,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7498,7 +7498,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.7.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7546,7 +7546,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.10.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7740,7 +7740,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -7749,7 +7749,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -7788,13 +7788,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -7863,7 +7863,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7891,7 +7891,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7960,7 +7960,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8016,7 +8016,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -8084,7 +8084,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8183,7 +8183,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8192,12 +8192,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -8265,12 +8265,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.7.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -8284,13 +8284,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.2.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.7.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -8307,12 +8307,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.23",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.7.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8332,12 +8332,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.7.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -8347,7 +8347,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8391,7 +8391,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8407,7 +8407,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -8416,7 +8416,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8439,12 +8439,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8492,34 +8492,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -8600,7 +8582,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8608,12 +8590,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -8935,7 +8917,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8959,17 +8941,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8986,12 +8968,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9060,7 +9042,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.15",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -9088,13 +9070,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9121,7 +9103,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9153,6 +9135,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -9545,9 +9536,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ export async function parseToDocxOptions(
     const headings: TocHeadingEntry[] = [];
     let maxSequenceId = 0;
     const processedImageCounter = { count: 0 };
+    const failedRemoteImageCounter = { count: 0 };
     const headingBookmarkCounter = { count: 0 };
     const tocPlaceholders = new WeakSet<object>();
     let elementCount = 0;
@@ -168,6 +169,7 @@ export async function parseToDocxOptions(
       const renderedModel = await modelToDocx(model, section.style, options, {
         sequenceIdOffset: maxSequenceId,
         processedImageCounter,
+        failedRemoteImageCounter,
         headingBookmarkCounter,
         tocPlaceholders,
         tableWidthTwips: getSectionContentWidthTwips(section.config),

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -32,7 +32,7 @@ import { Style, Options } from "./types.js";
  */
 function classifyHtmlNode(value: string): DocxBlockNode | null {
   if (value.includes("COMMENT:")) {
-    const match = value.match(/COMMENT:\s*(.+?)(?:-->)?/);
+    const match = value.match(/COMMENT:\s*([\s\S]*?)\s*(?:-->|$)/);
     if (match) {
       return { type: "comment", value: match[1].trim() };
     }

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -31,11 +31,11 @@ import { Style, Options } from "./types.js";
  * and the nested (blockquote/list) block walker.
  */
 function classifyHtmlNode(value: string): DocxBlockNode | null {
-  if (value.includes("COMMENT:")) {
-    const match = value.match(/COMMENT:\s*([\s\S]*?)\s*(?:-->|$)/);
-    if (match) {
-      return { type: "comment", value: match[1].trim() };
-    }
+  const commentMatch = value.match(
+    /^\s*<!--\s*COMMENT:\s*([\s\S]*?)\s*(?:-->\s*|$)/
+  );
+  if (commentMatch) {
+    return { type: "comment", value: commentMatch[1].trim() };
   }
   if (value.includes("pagebreak")) {
     return { type: "pageBreak" };

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -50,6 +50,25 @@ interface ListMarkerContext {
   sequenceId: number | undefined;
 }
 
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/**
+ * Hyperlink targets are restricted to a scheme allowlist so a malicious
+ * document cannot embed e.g. file:// UNC links (NTLM credential leak when
+ * clicked in Word on Windows) or other unexpected protocol handlers.
+ * Scheme-less (relative/fragment) targets carry no protocol to abuse and
+ * are allowed.
+ */
+function isSafeLinkUrl(url: string): boolean {
+  let protocol: string;
+  try {
+    protocol = new URL(url).protocol;
+  } catch {
+    return true;
+  }
+  return SAFE_LINK_PROTOCOLS.has(protocol.toLowerCase());
+}
+
 /**
  * Converts internal docx model to docx Paragraph/Table objects
  * Handles nested lists with proper level tracking
@@ -129,7 +148,9 @@ export async function modelToDocx(
   ): (TextRun | ExternalHyperlink)[] {
     const out: (TextRun | ExternalHyperlink)[] = [];
     for (const node of nodes) {
-      if (node.link) {
+      if (node.link && !isSafeLinkUrl(node.link)) {
+        out.push(textRunFromNode({ ...node, link: undefined }, overrides));
+      } else if (node.link) {
         out.push(
           new ExternalHyperlink({
             children: [

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -62,6 +62,8 @@ export async function modelToDocx(
     sequenceIdOffset?: number;
     /** When set by `parseToDocxOptions`, ties `maxImages` to the whole document across sections. */
     processedImageCounter?: { count: number };
+    /** Document-wide budget for failed remote image fetch attempts. */
+    failedRemoteImageCounter?: { count: number };
     headingBookmarkCounter?: { count: number };
     /** Records emitted TOC placeholder paragraphs so the caller can splice in TOC content. */
     tocPlaceholders?: WeakSet<object>;
@@ -83,6 +85,9 @@ export async function modelToDocx(
   const sequenceIdOffset = renderOptions.sequenceIdOffset || 0;
   const imageHandling = resolveImageHandlingOptions(options.imageHandling);
   const processedImageCounter = renderOptions.processedImageCounter ?? {
+    count: 0,
+  };
+  const failedRemoteImageCounter = renderOptions.failedRemoteImageCounter ?? {
     count: 0,
   };
   // Full-width tables are sized in twips so docx emits a plain integer width.
@@ -634,6 +639,15 @@ export async function modelToDocx(
       return [imageCouldNotLoadParagraph(node.alt, paragraphOptions)];
     }
 
+    // maxImages caps successful embeds only (so broken images cannot starve
+    // valid ones of budget), but failed *remote* attempts still cost up to
+    // fetchTimeoutMs each. Give failures their own equal budget so a document
+    // full of broken/slow URLs cannot trigger unbounded sequential fetches.
+    const isRemote = !/^data:/i.test(node.url);
+    if (isRemote && failedRemoteImageCounter.count >= imageHandling.maxImages) {
+      return [imageCouldNotLoadParagraph(node.alt, paragraphOptions)];
+    }
+
     try {
       const { embedded, paragraphs } = await processImage(
         node.alt,
@@ -645,6 +659,8 @@ export async function modelToDocx(
       );
       if (embedded) {
         processedImageCounter.count++;
+      } else if (isRemote) {
+        failedRemoteImageCounter.count++;
       }
       return paragraphs;
     } catch (error) {

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -56,15 +56,16 @@ const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
  * Hyperlink targets are restricted to a scheme allowlist so a malicious
  * document cannot embed e.g. file:// UNC links (NTLM credential leak when
  * clicked in Word on Windows) or other unexpected protocol handlers.
- * Scheme-less (relative/fragment) targets carry no protocol to abuse and
- * are allowed.
+ * Relative/fragment targets resolve against the dummy base and inherit its
+ * safe scheme; targets the URL parser rejects outright fail closed because
+ * Word may still treat the raw string as an active hyperlink.
  */
 function isSafeLinkUrl(url: string): boolean {
   let protocol: string;
   try {
-    protocol = new URL(url).protocol;
+    protocol = new URL(url, "https://relative-link.invalid/").protocol;
   } catch {
-    return true;
+    return false;
   }
   return SAFE_LINK_PROTOCOLS.has(protocol.toLowerCase());
 }

--- a/src/renderers/imageRenderer.ts
+++ b/src/renderers/imageRenderer.ts
@@ -16,10 +16,23 @@ export {
 export type { ResolvedImageHandlingOptions } from "../utils/secureImageFetch.js";
 
 /**
+ * Upper bound for rendered image dimensions in pixels. Hints come from
+ * attacker-controllable URL fragments (e.g. `img.png#99999999999x9`) and
+ * intrinsic sizes from untrusted image headers; unbounded values produce
+ * EMU numbers that Word rejects as a corrupt document.
+ */
+const MAX_IMAGE_DIMENSION = 10_000;
+
+function clampImageDimension(value: number): number {
+  return Math.min(Math.max(1, Math.round(value)), MAX_IMAGE_DIMENSION);
+}
+
+/**
  * Computes output image dimensions preserving aspect ratio.
  * - If both hints provided, uses them directly.
  * - If one hint provided and intrinsic aspect known, computes the other.
  * - Falls back to intrinsic width capped to 400, or default width 200.
+ * Results are clamped to [1, MAX_IMAGE_DIMENSION].
  */
 export function computeImageDimensions(
   widthHint: number | undefined,
@@ -50,7 +63,10 @@ export function computeImageDimensions(
     outWidth = 200;
   }
 
-  return { width: outWidth, height: outHeight };
+  return {
+    width: clampImageDimension(outWidth),
+    height: outHeight === undefined ? undefined : clampImageDimension(outHeight),
+  };
 }
 
 function readUint16BE(buf: Uint8Array, offset: number): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,8 @@ export interface RemoteImageHandlingOptions {
   enabled?: boolean;
   /**
    * Optional exact host allowlist. Host names are compared case-insensitively.
+   * When provided, the list fails closed: an empty array denies every host.
+   * Omit the option to allow any (public) host.
    */
   allowedHosts?: string[];
 }

--- a/src/utils/secureImageFetch.ts
+++ b/src/utils/secureImageFetch.ts
@@ -158,8 +158,11 @@ function enforceRemoteHttpsPolicy(
     throw new Error("Remote image URL exceeds maximum length");
   }
 
+  // An explicitly provided allowlist fails closed: an empty array denies
+  // every host rather than silently allowing all of them. Omit the option
+  // entirely to permit any (public) host.
   const allowedHosts = options.remote.allowedHosts;
-  if (allowedHosts && allowedHosts.length > 0) {
+  if (allowedHosts) {
     const hostname = url.hostname.toLowerCase();
     if (!allowedHosts.includes(hostname)) {
       throw new Error("Remote image host is not allowed");

--- a/tests/image-security.test.ts
+++ b/tests/image-security.test.ts
@@ -303,6 +303,38 @@ describe("Image security", () => {
     expect(xml.match(IMAGE_FALLBACK_GLOBAL)).toHaveLength(6);
   });
 
+  it("denies every remote host when an empty allowedHosts list is provided", async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected fetch"));
+
+    const xml = await render("![remote](https://93.184.216.34/image.png)", {
+      imageHandling: { remote: { enabled: true, allowedHosts: [] } },
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expectImageFallback(xml);
+  });
+
+  it("still fetches hosts present in the allowedHosts list", async () => {
+    const pngBytes = Buffer.from(ONE_PX_PNG.split(",")[1], "base64");
+    jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(pngBytes), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }) as never
+    );
+
+    const xml = await render("![remote](https://93.184.216.34/image.png)", {
+      imageHandling: {
+        remote: { enabled: true, allowedHosts: ["93.184.216.34"] },
+      },
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(xml).toContain("<w:drawing>");
+  });
+
   it("continues to embed valid data URL images by default", async () => {
     const xml = await render(`![one px](${ONE_PX_PNG})`);
 

--- a/tests/image-security.test.ts
+++ b/tests/image-security.test.ts
@@ -8,6 +8,7 @@ const ONE_PX_PNG =
 
 /** Matches fallback paragraphs from `processImage` (`displayed`) or `modelToDocx` (`loaded`). */
 const IMAGE_FALLBACK = /Image could not be (displayed|loaded)/;
+const IMAGE_FALLBACK_GLOBAL = /Image could not be (displayed|loaded)/g;
 
 function expectImageFallback(xml: string): void {
   expect(xml).toMatch(IMAGE_FALLBACK);
@@ -277,7 +278,29 @@ describe("Image security", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(xml.match(/<w:drawing>/g)).toHaveLength(1);
-    expect(xml.match(/Image could not be displayed/g)).toHaveLength(2);
+    expect(xml.match(IMAGE_FALLBACK_GLOBAL)).toHaveLength(2);
+  });
+
+  it("stops attempting remote fetches once the failed-image budget is spent", async () => {
+    let fetchCalls = 0;
+    jest.spyOn(globalThis, "fetch").mockImplementation(() => {
+      fetchCalls += 1;
+      return Promise.reject(new Error("connection refused"));
+    });
+
+    const markdown = Array.from(
+      { length: 6 },
+      (_, i) => `![broken](https://93.184.216.34/missing-${i}.png)`
+    ).join("\n\n");
+
+    const xml = await render(markdown, {
+      imageHandling: { remote: { enabled: true }, maxImages: 2 },
+    });
+
+    // Failed remote attempts get an equal budget to maxImages; once spent,
+    // remaining images fall back without performing network fetches.
+    expect(fetchCalls).toBe(2);
+    expect(xml.match(IMAGE_FALLBACK_GLOBAL)).toHaveLength(6);
   });
 
   it("continues to embed valid data URL images by default", async () => {

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -588,6 +588,24 @@ describe("Rendering: font family", () => {
   });
 });
 
+describe("Rendering: HTML comments", () => {
+  it("renders the full comment text, not just the first character", async () => {
+    const xml = await render(
+      "# Title\n\n<!-- COMMENT: hello world this is a note -->\n\nBody."
+    );
+
+    expect(xml).toContain("Comment: hello world this is a note");
+  });
+
+  it("renders multi-word comments inside blockquotes", async () => {
+    const xml = await render(
+      "> quoted\n>\n> <!-- COMMENT: reviewer feedback here -->"
+    );
+
+    expect(xml).toContain("Comment: reviewer feedback here");
+  });
+});
+
 describe("Rendering: error cases", () => {
   it("throws MarkdownConversionError for whitespace-only fontFamily", async () => {
     await expect(

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -606,6 +606,31 @@ describe("Rendering: HTML comments", () => {
   });
 });
 
+describe("Rendering: image dimension clamping", () => {
+  it("clamps oversized dimension hints from URL fragments", async () => {
+    const xml = await render(
+      `![huge](${ONE_PX_PNG}#99999999999x99999999999)`
+    );
+
+    // 10,000 px cap * 9525 EMU/px = 95,250,000.
+    const extents = Array.from(
+      xml.matchAll(/<wp:extent cx="(\d+)" cy="(\d+)"/g)
+    );
+    expect(extents.length).toBeGreaterThan(0);
+    for (const [, cx, cy] of extents) {
+      expect(Number(cx)).toBeLessThanOrEqual(10_000 * 9525);
+      expect(Number(cy)).toBeLessThanOrEqual(10_000 * 9525);
+    }
+  });
+
+  it("keeps reasonable dimension hints intact", async () => {
+    const xml = await render(`![sized](${ONE_PX_PNG}#300x150)`);
+
+    expect(xml).toContain(`cx="${300 * 9525}"`);
+    expect(xml).toContain(`cy="${150 * 9525}"`);
+  });
+});
+
 describe("Rendering: error cases", () => {
   it("throws MarkdownConversionError for whitespace-only fontFamily", async () => {
     await expect(

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -604,6 +604,14 @@ describe("Rendering: HTML comments", () => {
 
     expect(xml).toContain("Comment: reviewer feedback here");
   });
+
+  it("does not treat non-comment HTML containing COMMENT: as a comment", async () => {
+    const xml = await render(
+      "Before.\n\n<div>COMMENT: just markup text</div>\n\nAfter."
+    );
+
+    expect(xml).not.toContain("Comment:");
+  });
 });
 
 describe("Rendering: image dimension clamping", () => {

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -95,4 +95,47 @@ describe("Security regressions", () => {
     expect(canonicalLanguageName("javascript")).toBe("javascript");
     expect(canonicalLanguageName("js")).toBe("javascript");
   });
+
+  it("renders file:// UNC links as plain text instead of hyperlinks", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Open [report](file://attacker.example/share/doc.docx) now."
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("report");
+    expect(documentXml).not.toContain("<w:hyperlink");
+    expect(relationshipsXml).not.toContain("file://");
+  });
+
+  it("renders javascript: links as plain text instead of hyperlinks", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Click [here](javascript:alert(1))."
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("here");
+    expect(documentXml).not.toContain("<w:hyperlink");
+    expect(relationshipsXml).not.toContain("javascript:");
+  });
+
+  it("keeps https, mailto, and relative links as hyperlinks", async () => {
+    const blob = await convertMarkdownToDocx(
+      [
+        "[secure](https://example.com/ok)",
+        "[mail](mailto:user@example.com)",
+        "[relative](./other-doc.md)",
+      ].join(" and ")
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml.match(/<w:hyperlink/g)).toHaveLength(3);
+    expect(relationshipsXml).toContain("https://example.com/ok");
+    expect(relationshipsXml).toContain("mailto:user@example.com");
+  });
 });

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -122,6 +122,32 @@ describe("Security regressions", () => {
     expect(relationshipsXml).not.toContain("javascript:");
   });
 
+  it("renders whitespace-obfuscated unsafe schemes as plain text", async () => {
+    // The WHATWG URL parser strips tabs/newlines, so "java\tscript:" would
+    // otherwise normalize to javascript: after the allowlist check.
+    const blob = await convertMarkdownToDocx(
+      "Click [here](java\tscript:alert(1))."
+    );
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("here");
+    expect(documentXml).not.toContain("<w:hyperlink");
+    expect(relationshipsXml).not.toContain("script:");
+  });
+
+  it("fails closed on malformed link targets the URL parser rejects", async () => {
+    const blob = await convertMarkdownToDocx("Broken [target](https://).");
+
+    const documentXml = await getDocumentXml(blob);
+    const relationshipsXml = await documentRelationshipsXml(blob);
+
+    expect(documentXml).toContain("target");
+    expect(documentXml).not.toContain("<w:hyperlink");
+    expect(relationshipsXml).not.toContain('Target="https://"');
+  });
+
   it("keeps https, mailto, and relative links as hyperlinks", async () => {
     const blob = await convertMarkdownToDocx(
       [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements all fixes from a full security/bug audit of the repo. Each finding is a separate conventional commit.

### Dependency advisories — `chore(deps)`
`npm audit fix` clears all 5 dev-only advisories (minimatch/picomatch ReDoS, brace-expansion ReDoS, js-yaml prototype pollution, ip-address XSS — all transitive via eslint/jest/semantic-release). `npm audit` is now clean for both prod and dev trees. Lockfile-only change.

### Bug: HTML comments truncated to one character — `fix(comments)`
The lazy capture in `classifyHtmlNode` (`/COMMENT:\s*(.+?)(?:-->)?/`) was satisfied after a single character because `-->` was optional, so `<!-- COMMENT: hello world -->` rendered as `Comment: h`. The match is now anchored to the comment terminator or end of input. A follow-up (per CodeRabbit review) also anchors the match to a real `<!-- COMMENT:` opener so non-comment markup like `<div>COMMENT: x</div>` is no longer misclassified as a comment block.

### DoS: failed remote image fetches were unbounded — `fix(images)`
`maxImages` intentionally caps successful embeds only (#bc7caee), so a document full of broken/slow remote URLs never tripped it and could trigger unbounded sequential fetches, each costing up to `fetchTimeoutMs`. Failed remote attempts now get their own document-wide budget equal to `maxImages`; once spent, remaining remote images fall back without touching the network. Successful-embed semantics are preserved, and data URLs (cheap local decode) are unaffected.

### Hardening: image dimensions clamped — `fix(images)`
Width/height hints from URL fragments (`img.png#99999999999x9`) and intrinsic sizes from untrusted image headers flowed unclamped into `ImageRun` transformations, producing EMU values Word rejects as a corrupt document. All computed dimensions are now clamped to `[1, 10000]` px.

### Hardening: empty `allowedHosts` now fails closed — `fix(images)`
`remote.allowedHosts: []` previously meant "allow every host" — the opposite of the intuitive deny-all, and a foot-gun for callers building allowlists dynamically. An explicitly provided empty list now denies every host; omitting the option still allows any public host.

### Hardening: hyperlink scheme allowlist — `fix(links)`
Markdown link targets flowed unrestricted into `ExternalHyperlink`, allowing `file://` UNC links (NTLM credential leak when clicked in Word on Windows), `javascript:` URLs, etc. Only `http:`, `https:`, `mailto:`, `tel:`, and scheme-less relative/fragment targets become hyperlinks; anything else renders as plain text. A follow-up (per Bugbot review) makes the check fail **closed**: targets are parsed against a dummy `https:` base so relative links keep working, and anything the URL parser rejects outright renders as plain text instead of being trusted.

## Behavior changes

- `remote.allowedHosts: []` now denies all hosts instead of allowing all.
- Links with unsafe schemes or unparseable targets render as plain text instead of hyperlinks.
- After `maxImages` failed remote fetches, further remote images render the fallback paragraph without a network attempt.
- Image dimensions are capped at 10,000 px.
- `COMMENT:` markers are only recognized inside actual `<!-- ... -->` HTML comments.

## Testing

- 13 new regression tests covering every fix and both review findings (127 total, all passing).
- `npm run build`, `npm run lint`, `npm test` all green.
- Verified end-to-end on the built `dist/`: full comment text survives, `file://` targets are absent from `document.xml.rels` while `https://` links remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-602adbde-0def-4844-95e2-69b9fc4a902d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-602adbde-0def-4844-95e2-69b9fc4a902d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track failed remote image fetches separately to enforce image-budget limits; host allowlisting controls remote image fetching.
  * Validate URL schemes so only safe schemes render as clickable hyperlinks.

* **Bug Fixes**
  * More robust HTML comment parsing for multi-line content.
  * Clamp image dimensions to prevent extreme sizing.
  * Unsafe schemes rendered as plain text, not links.

* **Documentation**
  * Clarified allowedHosts deny-all behavior when empty.

* **Tests**
  * Added coverage for image-budget, host allowlisting, comment rendering, dimension clamping, and link-scheme safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->