### PR TITLE
fix: add untrusted text replacement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ await convertMarkdownToDocx(markdown, {
 
 ### Text find-and-replace
 
-Run string, regex, or functional replacements over the Markdown AST before conversion — they apply across every element type (headings, paragraphs, list items, table cells, etc.):
+Run string, regex, or trusted functional replacements over the Markdown AST before conversion — they apply across every element type (headings, paragraphs, list items, table cells, etc.):
 
 ```typescript
 await convertMarkdownToDocx(markdown, {
@@ -319,7 +319,9 @@ await convertMarkdownToDocx(markdown, {
 });
 ```
 
-For untrusted input, prefer literal string replacements. Regex replacements are accepted only when they fit bounded safety checks; patterns with nested quantifiers or excessive length are rejected before conversion to avoid ReDoS-style stalls.
+Function replacements execute JavaScript in the conversion process and must only be constructed by trusted programmatic callers. They are still supported by default for backward compatibility.
+
+For untrusted input, set `textReplacementMode: "untrusted"` and prefer literal string replacements. In untrusted mode, function replacements are rejected before conversion. Regex replacements are accepted only when they fit bounded safety checks; patterns with nested quantifiers or excessive length are rejected before conversion to avoid ReDoS-style stalls.
 
 Escaped link syntax such as `\[label](https://example.com)` stays plain text in the DOCX. Hyperlinks are emitted only from actual Markdown link nodes.
 
@@ -335,6 +337,7 @@ try {
   const blob = await convertMarkdownToDocx(markdown, {
     maxInputLength: 1_048_576,
     maxElements: 50_000,
+    textReplacementMode: "untrusted",
     signal: controller.signal,
     imageHandling: {
       remote: { enabled: false },
@@ -420,6 +423,7 @@ interface Options {
   sections?: DocumentSection[];
   codeHighlighting?: CodeHighlightOptions;
   textReplacements?: TextReplacement[];
+  textReplacementMode?: "trusted" | "untrusted";
   imageHandling?: ImageHandlingOptions;
 }
 ```
@@ -520,10 +524,14 @@ Alignment & direction
 #### `TextReplacement`
 
 
-| Field     | Type    |
-| --------- | ------- |
-| `find`    | `string |
-| `replace` | `string |
+| Field     | Type                                                        | Description                                                                 |
+| --------- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `find`    | `string \| RegExp`                                         | Pattern to find. Regex patterns are checked for bounded safety before use.  |
+| `replace` | `string \| TextReplacementFunction`                        | Literal replacement or trusted function replacement.                        |
+
+`textReplacementMode` defaults to `"trusted"` to preserve existing programmatic behavior. Set it to `"untrusted"` when options come from users, API requests, webhooks, uploaded JSON, or any other external source; that mode rejects `TextReplacementFunction` values before they can run.
+
+`TextReplacementFunction` returns `string`, a Markdown phrasing node, an array of phrasing nodes, `false`, `null`, or `undefined`, matching the supported `mdast-util-find-and-replace` replacement results.
 
 
 ### Errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,10 @@ export {
   SectionTemplate,
   Style,
   TableData,
+  TextReplacement,
+  TextReplacementFunction,
+  TextReplacementFunctionResult,
+  TextReplacementMode,
   TocOptions,
 } from "./types.js";
 
@@ -154,7 +158,11 @@ export async function parseToDocxOptions(
       await yieldToAbortSignal(options.signal);
 
       if (options.textReplacements && options.textReplacements.length > 0) {
-        applyTextReplacements(ast, options.textReplacements);
+        applyTextReplacements(
+          ast,
+          options.textReplacements,
+          options.textReplacementMode
+        );
       }
       throwIfAborted(options.signal);
       elementCount = enforceElementLimit(

--- a/src/markdownAst.ts
+++ b/src/markdownAst.ts
@@ -44,6 +44,10 @@ export function applyTextReplacements(
   replacements: TextReplacement[],
   mode: TextReplacementMode = "trusted"
 ): Root {
+  if (mode !== "trusted" && mode !== "untrusted") {
+    throw new Error("Invalid textReplacementMode: Must be trusted or untrusted");
+  }
+
   if (!replacements || replacements.length === 0) {
     return ast;
   }

--- a/src/markdownAst.ts
+++ b/src/markdownAst.ts
@@ -2,8 +2,9 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import { findAndReplace } from "mdast-util-find-and-replace";
+import type { FindAndReplaceList } from "mdast-util-find-and-replace";
 import type { Root } from "mdast";
-import type { TextReplacement } from "./types.js";
+import type { TextReplacement, TextReplacementMode } from "./types.js";
 
 const MAX_REPLACEMENTS = 50;
 const MAX_REPLACEMENT_PATTERN_LENGTH = 256;
@@ -40,7 +41,8 @@ export async function parseMarkdownToAst(markdown: string): Promise<Root> {
  */
 export function applyTextReplacements(
   ast: Root,
-  replacements: TextReplacement[]
+  replacements: TextReplacement[],
+  mode: TextReplacementMode = "trusted"
 ): Root {
   if (!replacements || replacements.length === 0) {
     return ast;
@@ -51,6 +53,11 @@ export function applyTextReplacements(
   }
 
   for (const replacement of replacements) {
+    if (mode === "untrusted" && typeof replacement.replace === "function") {
+      throw new Error(
+        'Function textReplacements are not allowed when textReplacementMode is "untrusted"'
+      );
+    }
     if (
       typeof replacement.replace === "string" &&
       replacement.replace.length > MAX_REPLACEMENT_TEXT_LENGTH
@@ -71,11 +78,10 @@ export function applyTextReplacements(
   // Convert replacements to the format expected by mdast-util-find-and-replace.
   // RegExp entries are intentionally constrained above; string entries are the
   // recommended mode for untrusted callers.
-  const findReplacePairs: Array<[string | RegExp, string | ((...args: any[]) => any)]> = 
-    replacements.map((replacement) => [
-      replacement.find,
-      replacement.replace,
-    ]);
+  const findReplacePairs: FindAndReplaceList = replacements.map((replacement) => [
+    replacement.find,
+    replacement.replace,
+  ]);
 
   // Apply all replacements to the AST
   findAndReplace(ast, findReplacePairs);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { PhrasingContent } from "mdast";
+
 export interface Style {
   titleSize: number;
   headingSpacing: number;
@@ -229,8 +231,17 @@ export interface Options {
   /**
    * Array of text replacements to apply to the markdown AST before conversion
    * Uses mdast-util-find-and-replace for pattern matching and replacement
+   * Function replacements are for trusted programmatic callers only. Set
+   * textReplacementMode to "untrusted" when replacement options come from
+   * external input.
    */
   textReplacements?: TextReplacement[];
+  /**
+   * Controls whether function text replacements are accepted. Defaults to
+   * "trusted" for backward compatibility. Use "untrusted" for API, webhook,
+   * upload, or CLI JSON options sourced from external users.
+   */
+  textReplacementMode?: TextReplacementMode;
   /**
    * Optional syntax highlighting configuration for fenced code blocks.
    * When `enabled` is true, lowlight is used to tokenize the code and
@@ -373,9 +384,24 @@ export interface TableData {
 /**
  * Configuration for text find-and-replace operations
  * @property find - The pattern to find (string or RegExp)
- * @property replace - The replacement (string or function that returns string or array of nodes)
+ * @property replace - The replacement (string or trusted function)
  */
+export type TextReplacementMode = "trusted" | "untrusted";
+
+export type TextReplacementFunctionResult =
+  | string
+  | PhrasingContent
+  | PhrasingContent[]
+  | false
+  | null
+  | undefined;
+
+export type TextReplacementFunction = (
+  match: string,
+  ...args: unknown[]
+) => TextReplacementFunctionResult;
+
 export interface TextReplacement {
   find: string | RegExp;
-  replace: string | ((match: string, ...args: any[]) => string | any);
+  replace: string | TextReplacementFunction;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -434,16 +434,16 @@ function validateProcessingLimitsInput(options: Options): void {
 }
 
 function validateTextReplacementInput(options: Options): void {
-  const mode = options.textReplacementMode ?? "trusted";
+  const mode = options.textReplacementMode;
 
-  if (!validTextReplacementModes.includes(mode)) {
+  if (mode !== undefined && !validTextReplacementModes.includes(mode)) {
     throw new MarkdownConversionError(
       "Invalid textReplacementMode: Must be trusted or untrusted",
       { textReplacementMode: options.textReplacementMode }
     );
   }
 
-  if (!options.textReplacements || mode !== "untrusted") {
+  if (!options.textReplacements || (mode ?? "trusted") !== "untrusted") {
     return;
   }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -49,6 +49,7 @@ const validSectionTypes = [
   "ODD_PAGE",
 ] as const;
 const validPageOrientations = ["PORTRAIT", "LANDSCAPE"] as const;
+const validTextReplacementModes = ["trusted", "untrusted"] as const;
 
 function validateHexColorOption(
   value: string | undefined,
@@ -432,6 +433,31 @@ function validateProcessingLimitsInput(options: Options): void {
   }
 }
 
+function validateTextReplacementInput(options: Options): void {
+  const mode = options.textReplacementMode ?? "trusted";
+
+  if (!validTextReplacementModes.includes(mode)) {
+    throw new MarkdownConversionError(
+      "Invalid textReplacementMode: Must be trusted or untrusted",
+      { textReplacementMode: options.textReplacementMode }
+    );
+  }
+
+  if (!options.textReplacements || mode !== "untrusted") {
+    return;
+  }
+
+  if (
+    options.textReplacements.some(
+      (replacement) => typeof replacement.replace === "function"
+    )
+  ) {
+    throw new MarkdownConversionError(
+      'Function textReplacements are not allowed when textReplacementMode is "untrusted"'
+    );
+  }
+}
+
 /**
  * Validates markdown input and options
  * @throws {MarkdownConversionError} If input is invalid
@@ -453,6 +479,7 @@ export function validateInput(markdown: string, options: Options): void {
   validateTocOptionsInput(options.toc);
   validateImageHandlingInput(options.imageHandling);
   validateProcessingLimitsInput(options);
+  validateTextReplacementInput(options);
 
   const normalizedTemplate = normalizeSectionConfig(options.template);
   if (normalizedTemplate) {

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -127,6 +127,15 @@ describe("Security regressions", () => {
     ).rejects.toThrow("Invalid textReplacementMode");
   });
 
+  it("rejects null textReplacementMode values", async () => {
+    await expect(
+      convertMarkdownToDocx("Hello", {
+        textReplacementMode: null as unknown as "trusted",
+        textReplacements: [{ find: "Hello", replace: "Hi" }],
+      })
+    ).rejects.toThrow("Invalid textReplacementMode");
+  });
+
   it("bounds bracket-heavy input without catastrophic scanning", async () => {
     const blob = await convertMarkdownToDocx("[".repeat(20_000));
     const documentXml = await getDocumentXml(blob);

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -119,6 +119,14 @@ describe("Security regressions", () => {
     );
   });
 
+  it("rejects invalid textReplacementMode values", async () => {
+    await expect(
+      convertMarkdownToDocx("Hello", {
+        textReplacementMode: "invalid" as unknown as "trusted",
+      })
+    ).rejects.toThrow("Invalid textReplacementMode");
+  });
+
   it("bounds bracket-heavy input without catastrophic scanning", async () => {
     const blob = await convertMarkdownToDocx("[".repeat(20_000));
     const documentXml = await getDocumentXml(blob);

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -79,6 +79,46 @@ describe("Security regressions", () => {
     ).rejects.toBeInstanceOf(MarkdownConversionError);
   });
 
+  it("rejects function text replacements in untrusted mode before execution", async () => {
+    const replacement = jest.fn((match: string) => `Number: ${match}`);
+
+    await expect(
+      convertMarkdownToDocx("Invoice 42", {
+        textReplacementMode: "untrusted",
+        textReplacements: [{ find: /(\d+)/g, replace: replacement }],
+      })
+    ).rejects.toThrow("Function textReplacements are not allowed");
+
+    expect(replacement).not.toHaveBeenCalled();
+  });
+
+  it("allows literal text replacements in untrusted mode", async () => {
+    const blob = await convertMarkdownToDocx("Company Name", {
+      textReplacementMode: "untrusted",
+      textReplacements: [{ find: "Company Name", replace: "Acme Corp" }],
+    });
+
+    const documentXml = await getDocumentXml(blob);
+    expect(documentXml).toContain("Acme Corp");
+    expect(documentXml).not.toContain("Company Name");
+  });
+
+  it("preserves trusted function text replacement behavior", async () => {
+    const replacement = jest.fn((match: string) => `Number: ${match}`);
+    const blob = await convertMarkdownToDocx("Invoice 42", {
+      textReplacementMode: "trusted",
+      textReplacements: [{ find: /(\d+)/g, replace: replacement }],
+    });
+
+    const documentXml = await getDocumentXml(blob);
+    expect(documentXml).toContain("Number: 42");
+    expect(replacement).toHaveBeenCalledWith(
+      "42",
+      "42",
+      expect.objectContaining({ index: 8 })
+    );
+  });
+
   it("bounds bracket-heavy input without catastrophic scanning", async () => {
     const blob = await convertMarkdownToDocx("[".repeat(20_000));
     const documentXml = await getDocumentXml(blob);


### PR DESCRIPTION
## Summary

- Adds `textReplacementMode` with a backward-compatible default of `"trusted"`.
- Rejects function-based `textReplacements` when callers opt into `"untrusted"` mode, before AST replacement execution.
- Tightens `TextReplacement` function return typing away from `any` and documents trusted vs untrusted usage.
- Adds regression coverage for untrusted rejection, untrusted literal replacements, and trusted function behavior.

## Validation

- `npm run build`
- `npm run test:single -- tests/security-regressions.test.ts`
- `npm test`
- `npm run lint`

Closes #39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the markdown AST replacement path used on untrusted server input; the change reduces code-execution risk but callers must opt into `"untrusted"` for external options.
> 
> **Overview**
> Introduces **`textReplacementMode`** on conversion options (`"trusted"` by default, `"untrusted"` for user/API-sourced config). In **untrusted** mode, **function** `textReplacements` are rejected during validation and again in `applyTextReplacements` before `findAndReplace` runs; string and bounded-regex replacements still work.
> 
> **`TextReplacement`** typing is tightened (exported `TextReplacementFunction` / result types instead of `any`), and README documents trusted vs untrusted usage—including `textReplacementMode: "untrusted"` in server-side limit examples. Security regression tests cover rejection before execution, literal replacements in untrusted mode, and preserved trusted function behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e32403f00ec25ba1507e19d6f3ee3363b989381b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `textReplacementMode` configuration option (defaulting to "trusted") to control text replacement behavior.
  * Introduced "untrusted" mode for safer handling of user-supplied text replacements, rejecting function-based replacements and enforcing bounded safety checks on patterns.

* **Documentation**
  * Updated documentation to describe the differences between trusted and untrusted text replacement modes with practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->