### PR TITLE
fix: align esm module resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Type check
         run: npm run build
 
+      - name: Verify package consumer imports
+        run: npm run test:consumer
+
       - name: Run tests
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "tsc",
     "lint": "eslint src tests",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.mjs",
+    "test:consumer": "node tests/package-consumer.mjs",
     "test:single": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.mjs",
     "prepare": "npm run build",
     "release": "semantic-release"

--- a/tests/package-consumer.mjs
+++ b/tests/package-consumer.mjs
@@ -109,16 +109,6 @@ try {
       cwd: consumerDir,
     });
   }
-
-  run(
-    process.execPath,
-    [
-      "--input-type=module",
-      "-e",
-      'const pkg = await import("@mohtasham/md-to-docx"); if (typeof pkg.convertMarkdownToDocx !== "function") throw new Error("missing root export");',
-    ],
-    { cwd: consumerDir }
-  );
 } finally {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 }

--- a/tests/package-consumer.mjs
+++ b/tests/package-consumer.mjs
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const tempRoot = fs.mkdtempSync(
+  path.join(repoRoot, "node_modules", ".package-consumer-")
+);
+const packDir = path.join(tempRoot, "pack");
+const consumerDir = path.join(tempRoot, "consumer");
+const packageDir = path.join(
+  consumerDir,
+  "node_modules",
+  "@mohtasham",
+  "md-to-docx"
+);
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}${os.EOL}`);
+}
+
+try {
+  fs.mkdirSync(packDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+
+  const tarballName = execFileSync(
+    "npm",
+    ["pack", "--ignore-scripts", "--pack-destination", packDir, "--silent"],
+    { cwd: repoRoot, encoding: "utf8" }
+  ).trim();
+  const tarballPath = path.join(packDir, tarballName);
+
+  run("tar", ["-xzf", tarballPath, "-C", packageDir, "--strip-components=1"]);
+
+  writeJson(path.join(consumerDir, "package.json"), {
+    type: "module",
+    dependencies: {
+      "@mohtasham/md-to-docx": "file:./node_modules/@mohtasham/md-to-docx",
+    },
+  });
+
+  fs.writeFileSync(
+    path.join(consumerDir, "index.ts"),
+    [
+      'import { convertMarkdownToDocx } from "@mohtasham/md-to-docx";',
+      "",
+      "async function main() {",
+      '  const doc = await convertMarkdownToDocx("# Hello");',
+      "  console.log(doc instanceof Blob);",
+      "}",
+      "",
+      "void main();",
+      "",
+    ].join(os.EOL)
+  );
+
+  const configs = {
+    node16: {
+      target: "ES2020",
+      module: "Node16",
+      moduleResolution: "Node16",
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+    },
+    nodenext: {
+      target: "ES2020",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+    },
+    bundler: {
+      target: "ES2020",
+      module: "ES2020",
+      moduleResolution: "bundler",
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+    },
+  };
+
+  for (const [name, compilerOptions] of Object.entries(configs)) {
+    writeJson(path.join(consumerDir, `tsconfig.${name}.json`), {
+      compilerOptions,
+      include: ["index.ts"],
+    });
+  }
+
+  const tscPath = path.join(repoRoot, "node_modules", "typescript", "bin", "tsc");
+
+  for (const name of Object.keys(configs)) {
+    console.log(`Verifying consumer import with ${name} resolution`);
+    run(process.execPath, [tscPath, "-p", `tsconfig.${name}.json`], {
+      cwd: consumerDir,
+    });
+  }
+
+  run(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      'const pkg = await import("@mohtasham/md-to-docx"); if (typeof pkg.convertMarkdownToDocx !== "function") throw new Error("missing root export");',
+    ],
+    { cwd: consumerDir }
+  );
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Release note
Use `fix: align esm module resolution` as the squash commit title if this should publish a patch release via semantic-release. This PR resolves package/module-resolution friction from #37, so a `fix:` squash title is appropriate when merging for release.

## Summary
- Align the package TypeScript config with the ESM package shape by switching to `module`/`moduleResolution: Node16`.
- Add a packed-package consumer import check for `Node16`, `NodeNext`, and `bundler` TypeScript consumers.
- Run that consumer check in CI after the package build.

## Issue #37 verification
Before changing anything, I packed the current package from `origin/main` and installed it into a disposable consumer project. The root import compiled successfully with TypeScript `Node16`, `NodeNext`, and `bundler` resolution, so I could not reproduce an active TypeScript consumer resolution failure.

The stale mismatch still existed in `tsconfig.json`, though. This PR closes that remaining configuration gap while preserving the emitted build output byte-for-byte.

During CI validation, an attempted runtime root import assertion exposed a separate pre-existing Node 18 runtime compatibility issue: importing the package can load `undici@7`, which references global `File`; Node 18.20.8 does not provide that global. That assertion was removed because #37 is scoped to TypeScript/package resolution, not runtime Node 18 import behavior.

Closes #37.

## Validation
- `npm run build`
- `npm run test:consumer`
- `npm test`
- `npm run lint`
- Compared `dist` against a fresh build with the new config; no output differences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and TypeScript config only; PR description notes `dist` output is unchanged byte-for-byte.
> 
> **Overview**
> Aligns the library’s TypeScript compiler settings with its ESM `package.json` shape by switching **`module` / `moduleResolution`** from legacy `ES2020` / `node` to **`Node16`**.
> 
> Adds a **`test:consumer`** harness that **`npm pack`s** the built package into a disposable app and runs **`tsc`** against a root import of `convertMarkdownToDocx` under **Node16**, **NodeNext**, and **bundler** resolution. CI runs this step **after `npm run build`** and before unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52fd0e3b0694d86449cdae449edf08149d58c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
