### PR TITLE
feat: support github-style callout blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This document was generated from **Markdown** in TypeScript.
 
 - Supports lists
 - **Bold**, *italic*, ++underline++, ~~strikethrough~~
-- Tables, blockquotes, images, and code blocks
+- Tables, blockquotes, GitHub-style callouts, images, and code blocks
 
 \`\`\`ts
 const greet = (name: string) => \`Hello, \${name}!\`;
@@ -283,6 +283,39 @@ await convertMarkdownToDocx(markdown, {
 
 Set `headingAlignment` to provide a fallback for any level without its own override.
 
+### GitHub-style callouts
+
+GitHub-style blockquote callouts render as styled DOCX callout blocks:
+
+```markdown
+> [!NOTE]
+> Use callouts for supporting information with **inline formatting**.
+>
+> Additional quoted paragraphs stay inside the callout.
+
+> [!WARNING]
+> Warning content renders with warning styling.
+```
+
+Supported callout markers are `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`.
+Unsupported markers, such as `> [!INFO]`, are rendered as ordinary blockquotes with the marker text preserved. Container-directive syntax such as `:::note` is not parsed and falls back to normal Markdown text.
+
+Callout colors can be customized per type:
+
+```typescript
+await convertMarkdownToDocx(markdown, {
+  style: {
+    calloutStyles: {
+      warning: {
+        borderColor: "B45309",
+        backgroundColor: "FFF7ED",
+        titleColor: "92400E",
+      },
+    },
+  },
+});
+```
+
 ### Table of Contents styling
 
 Drop `[TOC]` on its own line in your markdown to render a clickable, auto-populated table of contents. Every TOC level is individually styleable:
@@ -442,6 +475,7 @@ Text sizes
 | `inlineCodeColor`                             | `string`              | Inline code text color, RRGGBB           |
 | `inlineCodeBackground`                        | `string`              | Inline code background, RRGGBB           |
 | `blockquoteSize`                              | `number`              | Blockquote size                          |
+| `calloutStyles`                               | `Record<CalloutType, CalloutStyle>` | GitHub-style callout color overrides |
 | `tocFontSize`                                 | `number`              | TOC entry size (fallback for all levels) |
 | `tocHeading1FontSize` … `tocHeading6FontSize` | `number`              | Per-level TOC entry size                 |
 | `tocHeading1Bold` … `tocHeading6Bold`         | `boolean`             | Per-level TOC entry bold flag            |

--- a/src/docxModel.ts
+++ b/src/docxModel.ts
@@ -43,9 +43,17 @@ export interface DocxCodeBlockNode {
   value: string;
 }
 
+export type DocxCalloutType =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution";
+
 export interface DocxBlockquoteNode {
   type: "blockquote";
   children: DocxBlockNode[];
+  calloutType?: DocxCalloutType;
 }
 
 export interface DocxImageNode {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,8 @@ const defaultOptions: Options = {
 export { MarkdownConversionError };
 
 export {
+  CalloutStyle,
+  CalloutType,
   CodeHighlightOptions,
   CodeHighlightTheme,
   DataUrlImageHandlingOptions,

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -20,10 +20,14 @@ import type {
 import type {
   DocxDocumentModel,
   DocxBlockNode,
+  DocxCalloutType,
   DocxTextNode,
   DocxListItemNode,
 } from "./docxModel.js";
 import { Style, Options } from "./types.js";
+
+const GITHUB_CALLOUT_MARKER =
+  /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*(?:\r?\n[ \t]*)?/i;
 
 /**
  * Classifies a raw HTML node value into a comment or page-break block, or
@@ -41,6 +45,40 @@ function classifyHtmlNode(value: string): DocxBlockNode | null {
     return { type: "pageBreak" };
   }
   return null;
+}
+
+function stripGithubCalloutMarker(
+  paragraph: Paragraph,
+): { calloutType: DocxCalloutType; paragraph: Paragraph | null } | null {
+  const firstChild = paragraph.children[0];
+  if (!firstChild || firstChild.type !== "text") {
+    return null;
+  }
+
+  const markerMatch = firstChild.value.match(GITHUB_CALLOUT_MARKER);
+  if (!markerMatch) {
+    return null;
+  }
+
+  const calloutType = markerMatch[1].toLowerCase() as DocxCalloutType;
+  const remainingValue = firstChild.value.slice(markerMatch[0].length);
+  const children = [
+    ...(remainingValue.length > 0
+      ? [{ ...firstChild, value: remainingValue }]
+      : []),
+    ...paragraph.children.slice(1),
+  ] as Paragraph["children"];
+
+  return {
+    calloutType,
+    paragraph:
+      children.length > 0
+        ? {
+            ...paragraph,
+            children,
+          }
+        : null,
+  };
 }
 
 /**
@@ -220,7 +258,19 @@ export function mdastToDocxModel(
 
   function processBlockquote(blockquote: Blockquote): DocxBlockNode {
     const children: DocxBlockNode[] = [];
-    for (const child of blockquote.children) {
+    const firstChild = blockquote.children[0];
+    const callout =
+      firstChild?.type === "paragraph"
+        ? stripGithubCalloutMarker(firstChild as Paragraph)
+        : null;
+    const blockquoteChildren = callout
+      ? [
+          ...(callout.paragraph ? [callout.paragraph] : []),
+          ...blockquote.children.slice(1),
+        ]
+      : blockquote.children;
+
+    for (const child of blockquoteChildren) {
       const processed = processNode(child);
       if (processed) {
         if (Array.isArray(processed)) {
@@ -233,6 +283,7 @@ export function mdastToDocxModel(
     return {
       type: "blockquote",
       children,
+      calloutType: callout?.calloutType,
     };
   }
 

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -14,6 +14,7 @@ import type { IParagraphOptions } from "docx";
 import type {
   DocxDocumentModel,
   DocxBlockNode,
+  DocxCalloutType,
   DocxListNode,
   DocxListItemNode,
   DocxTextNode,
@@ -21,7 +22,10 @@ import type {
 import { Style, Options } from "./types.js";
 import { processHeading } from "./renderers/headingRenderer.js";
 import { processCodeBlock } from "./renderers/codeRenderer.js";
-import { blockquoteParagraphStyle } from "./renderers/blockquoteRenderer.js";
+import {
+  blockquoteParagraphStyle,
+  resolveCalloutStyle,
+} from "./renderers/blockquoteRenderer.js";
 import { processComment } from "./renderers/commentRenderer.js";
 import {
   processImage,
@@ -37,11 +41,13 @@ import { MarkdownConversionError } from "./errors.js";
 interface InlineOverrides {
   forceBold?: boolean;
   forceItalic?: boolean;
+  color?: string;
   size?: number;
 }
 
 interface RenderContext {
   quoteLevel?: number;
+  calloutType?: DocxCalloutType;
 }
 
 interface ListMarkerContext {
@@ -136,7 +142,7 @@ export async function modelToDocx(
       italics: overrides.forceItalic || node.italic,
       strike: node.strikethrough,
       underline: node.underline ? { type: "single" } : undefined,
-      color: node.link ? "0000FF" : "000000",
+      color: overrides.color || (node.link ? "0000FF" : "000000"),
       size: overrides.size || style.paragraphSize || 24,
       font: resolveFontFamily(style),
       rightToLeft: style.direction === "RTL",
@@ -190,7 +196,11 @@ export async function modelToDocx(
       ? AlignmentType[style.paragraphAlignment]
       : AlignmentType.LEFT;
     const quoteStyle = context.quoteLevel
-      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      ? blockquoteParagraphStyle(
+          style,
+          context.quoteLevel,
+          context.calloutType,
+        )
       : undefined;
     return new Paragraph({
       children: renderInlineNodes(nodes, overrides),
@@ -281,7 +291,11 @@ export async function modelToDocx(
     context: RenderContext = {},
   ): Paragraph {
     const quoteStyle = context.quoteLevel
-      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      ? blockquoteParagraphStyle(
+          style,
+          context.quoteLevel,
+          context.calloutType,
+        )
       : undefined;
     const base = {
       children: renderInlineNodes(nodes, { size: style.listItemSize || 24 }),
@@ -315,7 +329,11 @@ export async function modelToDocx(
     context: RenderContext = {},
   ): Paragraph {
     const quoteStyle = context.quoteLevel
-      ? blockquoteParagraphStyle(style, context.quoteLevel)
+      ? blockquoteParagraphStyle(
+          style,
+          context.quoteLevel,
+          context.calloutType,
+        )
       : undefined;
 
     return new Paragraph({
@@ -403,7 +421,11 @@ export async function modelToDocx(
                 font: resolveFontFamily(style),
               }),
             ],
-            ...blockquoteParagraphStyle(style, context.quoteLevel),
+            ...blockquoteParagraphStyle(
+              style,
+              context.quoteLevel,
+              context.calloutType,
+            ),
           }),
         ];
       }
@@ -430,16 +452,42 @@ export async function modelToDocx(
   ): Promise<(Paragraph | Table)[]> {
     throwIfAborted(options.signal);
 
-    const quoteContext = { quoteLevel: (context.quoteLevel || 0) + 1 };
+    const quoteContext = {
+      quoteLevel: (context.quoteLevel || 0) + 1,
+      calloutType: node.calloutType || context.calloutType,
+    };
     const out: (Paragraph | Table)[] = [];
-
-    if (node.children.length === 0) {
-      out.push(
-        paragraphFromInlineNodes([], quoteContext, {
+    const blockquoteTextOverrides: InlineOverrides = node.calloutType
+      ? { size: style.blockquoteSize || 24 }
+      : {
           size: style.blockquoteSize || 24,
           forceItalic: true,
-        }),
+        };
+
+    if (node.calloutType) {
+      const calloutStyle = resolveCalloutStyle(style, node.calloutType);
+      out.push(
+        paragraphFromInlineNodes(
+          [{ type: "text", value: calloutStyle.label }],
+          quoteContext,
+          {
+            size: style.blockquoteSize || 24,
+            forceBold: true,
+            color: calloutStyle.titleColor,
+          },
+        ),
       );
+    }
+
+    if (node.children.length === 0) {
+      if (!node.calloutType) {
+        out.push(
+          paragraphFromInlineNodes([], quoteContext, {
+            size: style.blockquoteSize || 24,
+            forceItalic: true,
+          }),
+        );
+      }
       return out;
     }
 
@@ -448,10 +496,11 @@ export async function modelToDocx(
 
       if (child.type === "paragraph") {
         out.push(
-          paragraphFromInlineNodes(child.children, quoteContext, {
-            size: style.blockquoteSize || 24,
-            forceItalic: true,
-          }),
+          paragraphFromInlineNodes(
+            child.children,
+            quoteContext,
+            blockquoteTextOverrides,
+          ),
         );
         continue;
       }
@@ -579,7 +628,11 @@ export async function modelToDocx(
     if (context.quoteLevel) {
       options = {
         ...options,
-        ...blockquoteParagraphStyle(style, context.quoteLevel),
+        ...blockquoteParagraphStyle(
+          style,
+          context.quoteLevel,
+          context.calloutType,
+        ),
       };
     }
 

--- a/src/renderers/blockquoteRenderer.ts
+++ b/src/renderers/blockquoteRenderer.ts
@@ -1,5 +1,5 @@
 import { AlignmentType, BorderStyle } from "docx";
-import { Style } from "../types.js";
+import { CalloutType, Style } from "../types.js";
 
 const BLOCKQUOTE_ALIGNMENTS: Record<
   NonNullable<Style["blockquoteAlignment"]>,
@@ -26,8 +26,61 @@ export interface BlockquoteParagraphStyle {
       color: string;
     };
   };
+  shading?: {
+    fill: string;
+  };
   alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
   bidirectional: boolean;
+}
+
+interface ResolvedCalloutStyle {
+  label: string;
+  borderColor: string;
+  backgroundColor: string;
+  titleColor: string;
+}
+
+const DEFAULT_CALLOUT_STYLES: Record<CalloutType, ResolvedCalloutStyle> = {
+  note: {
+    label: "Note",
+    borderColor: "0969DA",
+    backgroundColor: "EFF6FF",
+    titleColor: "0969DA",
+  },
+  tip: {
+    label: "Tip",
+    borderColor: "1A7F37",
+    backgroundColor: "F0FFF4",
+    titleColor: "1A7F37",
+  },
+  important: {
+    label: "Important",
+    borderColor: "8250DF",
+    backgroundColor: "F6F0FF",
+    titleColor: "8250DF",
+  },
+  warning: {
+    label: "Warning",
+    borderColor: "BF8700",
+    backgroundColor: "FFF8C5",
+    titleColor: "9A6700",
+  },
+  caution: {
+    label: "Caution",
+    borderColor: "CF222E",
+    backgroundColor: "FFF1F1",
+    titleColor: "CF222E",
+  },
+};
+
+export function resolveCalloutStyle(
+  style: Style,
+  calloutType: CalloutType,
+): ResolvedCalloutStyle {
+  return {
+    ...DEFAULT_CALLOUT_STYLES[calloutType],
+    ...style.calloutStyles?.[calloutType],
+  };
 }
 
 /**
@@ -37,9 +90,13 @@ export interface BlockquoteParagraphStyle {
 export function blockquoteParagraphStyle(
   style: Style,
   quoteLevel: number,
+  calloutType?: CalloutType,
 ): BlockquoteParagraphStyle {
   const alignment = style.blockquoteAlignment
     ? BLOCKQUOTE_ALIGNMENTS[style.blockquoteAlignment]
+    : undefined;
+  const calloutStyle = calloutType
+    ? resolveCalloutStyle(style, calloutType)
     : undefined;
 
   return {
@@ -54,9 +111,14 @@ export function blockquoteParagraphStyle(
       left: {
         style: BorderStyle.SINGLE,
         size: 3,
-        color: "AAAAAA",
+        color: calloutStyle?.borderColor || "AAAAAA",
       },
     },
+    shading: calloutStyle
+      ? {
+          fill: calloutStyle.backgroundColor,
+        }
+      : undefined,
     alignment,
     bidirectional: style.direction === "RTL",
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface Style {
   inlineCodeSize?: number;
   inlineCodeColor?: string;
   inlineCodeBackground?: string;
+  calloutStyles?: Partial<Record<CalloutType, CalloutStyle>>;
   tocFontSize?: number;
   // TOC level-specific styling
   tocHeading1FontSize?: number;
@@ -64,6 +65,28 @@ export interface Style {
 }
 
 export type AlignmentOption = "LEFT" | "CENTER" | "RIGHT" | "JUSTIFIED";
+
+export type CalloutType =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution";
+
+export interface CalloutStyle {
+  /**
+   * Left border color for GitHub-style callouts, as RRGGBB.
+   */
+  borderColor?: string;
+  /**
+   * Paragraph shading fill for GitHub-style callouts, as RRGGBB.
+   */
+  backgroundColor?: string;
+  /**
+   * Label text color for GitHub-style callouts, as RRGGBB.
+   */
+  titleColor?: string;
+}
 
 export type SectionPageNumberDisplay =
   | "none"

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,6 @@
 import {
   AlignmentOption,
+  CalloutType,
   DocumentSection,
   HeaderFooterGroup,
   HeaderFooterSlot,
@@ -49,6 +50,13 @@ const validSectionTypes = [
   "ODD_PAGE",
 ] as const;
 const validPageOrientations = ["PORTRAIT", "LANDSCAPE"] as const;
+const validCalloutTypes: CalloutType[] = [
+  "note",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+];
 
 function validateHexColorOption(
   value: string | undefined,
@@ -120,6 +128,56 @@ function validateStyleInput(
     "inlineCodeBackground",
     styleContext
   );
+
+  if (style.calloutStyles !== undefined) {
+    if (
+      typeof style.calloutStyles !== "object" ||
+      style.calloutStyles === null ||
+      Array.isArray(style.calloutStyles)
+    ) {
+      throw new MarkdownConversionError("Invalid calloutStyles: Must be an object", {
+        styleContext,
+        calloutStyles: style.calloutStyles,
+      });
+    }
+
+    for (const [calloutType, calloutStyle] of Object.entries(
+      style.calloutStyles
+    )) {
+      if (!validCalloutTypes.includes(calloutType as CalloutType)) {
+        throw new MarkdownConversionError(
+          `Invalid calloutStyles key: ${calloutType}`,
+          { styleContext, calloutType }
+        );
+      }
+      if (
+        typeof calloutStyle !== "object" ||
+        calloutStyle === null ||
+        Array.isArray(calloutStyle)
+      ) {
+        throw new MarkdownConversionError(
+          `Invalid calloutStyles.${calloutType}: Must be an object`,
+          { styleContext, calloutStyle }
+        );
+      }
+
+      validateHexColorOption(
+        calloutStyle.borderColor,
+        `calloutStyles.${calloutType}.borderColor`,
+        styleContext
+      );
+      validateHexColorOption(
+        calloutStyle.backgroundColor,
+        `calloutStyles.${calloutType}.backgroundColor`,
+        styleContext
+      );
+      validateHexColorOption(
+        calloutStyle.titleColor,
+        `calloutStyles.${calloutType}.titleColor`,
+        styleContext
+      );
+    }
+  }
 }
 
 function validateTocOptionsInput(toc: TocOptions | undefined): void {

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -191,6 +191,78 @@ Another paragraph with justified alignment.`;
     expect(xml).toContain("quoted item");
     expect(numberingLevels(xml)).toEqual(["0", "1", "0"]);
   });
+
+  const calloutCases = [
+    ["note", "NOTE", "Note", "0969DA", "EFF6FF"],
+    ["tip", "TIP", "Tip", "1A7F37", "F0FFF4"],
+    ["important", "IMPORTANT", "Important", "8250DF", "F6F0FF"],
+    ["warning", "WARNING", "Warning", "BF8700", "FFF8C5"],
+    ["caution", "CAUTION", "Caution", "CF222E", "FFF1F1"],
+  ] as const;
+
+  for (const [name, marker, label, borderColor, backgroundColor] of calloutCases) {
+    it(`renders GitHub-style ${name} callouts with variant styling`, async () => {
+      const xml = await render(`> [!${marker}]
+> ${label} body.`);
+
+      expect(xml).toContain(label);
+      expect(xml).toContain(`${label} body.`);
+      expect(xml).not.toContain(`[!${marker}]`);
+      expect(xml).toContain(`w:color="${borderColor}"`);
+      expect(xml).toContain(`w:fill="${backgroundColor}"`);
+    });
+  }
+
+  it("preserves inline formatting and nested paragraphs inside callouts", async () => {
+    const blob = await convertMarkdownToDocx(`> [!NOTE]
+> First **bold** paragraph with [lnk](https://example.com/callout) and \`code\`.
+>
+> Second paragraph.`);
+    const xml = await getDocumentXml(blob);
+    const rels = await (await getZip(blob))
+      .file("word/_rels/document.xml.rels")
+      ?.async("string");
+
+    expect(xml).toContain("Note");
+    expect(xml).toContain("First ");
+    expect(xml).toContain("Second paragraph.");
+    expect(xml).toMatch(/<w:b\/>(?:(?!<\/w:r>)[\s\S])*?>bold<\/w:t>/);
+    expect(xml).toContain("<w:hyperlink");
+    expect(rels).toContain("https://example.com/callout");
+    expect(xml).toContain('w:ascii="Courier New"');
+    expect(xml).not.toContain("[!NOTE]");
+  });
+
+  it("applies configured GitHub-style callout colors", async () => {
+    const xml = await render(`> [!WARNING]
+> Custom warning.`, {
+      style: {
+        calloutStyles: {
+          warning: {
+            borderColor: "112233",
+            backgroundColor: "FFEEDD",
+            titleColor: "445566",
+          },
+        },
+      },
+    });
+
+    expect(xml).toContain("Warning");
+    expect(xml).toContain("Custom warning.");
+    expect(xml).toContain('w:color="112233"');
+    expect(xml).toContain('w:fill="FFEEDD"');
+    expect(xml).toContain('w:val="445566"');
+  });
+
+  it("keeps unsupported GitHub-style callout markers as normal blockquotes", async () => {
+    const xml = await render(`> [!INFO]
+> Unsupported info callout.`);
+
+    expect(xml).toContain("[!INFO]");
+    expect(xml).toContain("Unsupported info callout.");
+    expect(xml).toContain('w:color="AAAAAA"');
+    expect(xml).not.toContain('w:fill="EFF6FF"');
+  });
 });
 
 describe("Rendering: inline formatting", () => {


### PR DESCRIPTION
## Summary

- Add GitHub-style blockquote callout detection for NOTE, TIP, IMPORTANT, WARNING, and CAUTION.
- Render callouts with labels plus distinct border/background/title colors, configurable through `style.calloutStyles`.
- Preserve inline formatting, links, inline code, lists, images, and multi-paragraph content inside supported callouts.
- Document supported syntax, unsupported marker fallback, and current directive-container fallback behavior.

Closes #57.

## Validation

- `npm run build`
- `npm run test:single -- tests/rendering.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Markdown rendering and style options; blockquote behavior only changes for recognized callout markers, with tests covering variants and fallbacks.
> 
> **Overview**
> Adds **GitHub-style blockquote callouts** (`> [!NOTE]`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`) so they render as styled DOCX callouts instead of plain italic blockquotes.
> 
> The mdast pipeline **detects and strips** the marker on the first paragraph, tags the blockquote with `calloutType`, and the renderer emits a **bold type label** plus body text with **per-type border, background, and title colors**. Callout body text is **not forced italic**; unsupported markers (e.g. `[!INFO]`) stay normal blockquotes with the marker text kept.
> 
> New public types **`CalloutType`** and **`CalloutStyle`**, plus **`style.calloutStyles`** for hex color overrides, with validation on keys and colors. README documents syntax, fallback behavior, and customization. Rendering tests cover all five types, inline formatting, custom colors, and unsupported markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afffd38ac02947947c3e23961cfa9cb00c9331e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->