### PR TITLE
feat: support Markdown footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [types](https://www.npmjs.com/package/@mohtasham/md-to-docx)
 [node](https://nodejs.org)
 
-A TypeScript-first library and CLI that turns Markdown into production-ready Word documents: headings, tables, lists, images, code blocks with optional syntax highlighting, multi-section templates, per-section headers/footers, page numbering, TOC, and fine-grained style control.
+A TypeScript-first library and CLI that turns Markdown into production-ready Word documents: headings, tables, lists, footnotes, images, code blocks with optional syntax highlighting, multi-section templates, per-section headers/footers, page numbering, TOC, and fine-grained style control.
 
 ---
 
@@ -362,24 +362,34 @@ await convertMarkdownToDocx(markdown, {
 ## Supported Markdown
 
 
-| Feature           | Syntax                 | Notes                                                |
-| ----------------- | ---------------------- | ---------------------------------------------------- |
-| Headings          | `# … ######`           | H1–H6, individually styleable                        |
-| Bold / italic     | `**bold**`, `*italic*` |                                                      |
-| Underline         | `++underline++`        | Custom marker                                        |
-| Strikethrough     | `~~text~~`             | GFM                                                  |
-| Inline code       | `code`                 |                                                      |
-| Code blocks       | ````` fenced           | Optional syntax highlighting per block               |
-| Lists             | `-`, `*`, `1.`         | Bullet, numbered, nested, rich formatting inside     |
-| Tables            | `                      | a                                                    |
-| Blockquotes       | `> text`               |                                                      |
-| Links             | `[text](url)`          |                                                      |
-| Images            | `![alt](url)`          | HTTP(S) and `data:` URLs; supports `#w=…&h=…` sizing |
-| Horizontal rule   | `---`                  | Skipped during conversion                            |
-| Table of Contents | `[TOC]`                | Clickable, auto-populated                            |
-| Page break        | `\pagebreak`           | Place on its own line                                |
-| Comments          | `COMMENT: text`        | Rendered as Word comments                            |
+| Feature           | Syntax                         | Notes                                                |
+| ----------------- | ------------------------------ | ---------------------------------------------------- |
+| Headings          | `# ... ######`                 | H1-H6, individually styleable                        |
+| Bold / italic     | `**bold**`, `*italic*`         |                                                      |
+| Underline         | `++underline++`                | Custom marker                                        |
+| Strikethrough     | `~~text~~`                     | GFM                                                  |
+| Inline code       | `` `code` ``                   |                                                      |
+| Code blocks       | ````` fenced                   | Optional syntax highlighting per block               |
+| Lists             | `-`, `*`, `1.`                 | Bullet, numbered, nested, rich formatting inside     |
+| Tables            | `\| a \| b \|`                 | GFM tables                                           |
+| Blockquotes       | `> text`                       |                                                      |
+| Links             | `[text](url)`                  |                                                      |
+| Images            | `![alt](url)`                  | HTTP(S) and `data:` URLs; supports `#w=...&h=...` sizing |
+| Footnotes         | `Text[^1]` + `[^1]: Note text` | Native Word footnotes                                |
+| Horizontal rule   | `---`                          | Skipped during conversion                            |
+| Table of Contents | `[TOC]`                        | Clickable, auto-populated                            |
+| Page break        | `\pagebreak`                   | Place on its own line                                |
+| Comments          | `<!-- COMMENT: text -->`       | Rendered as Word comments                            |
 
+Markdown footnotes use the GFM/remark syntax:
+
+```markdown
+Text with a note[^1].
+
+[^1]: Footnote text with **formatting**, [links](https://example.com), and `code`.
+```
+
+Referenced definitions are emitted to `word/footnotes.xml` as native Word footnotes. Inline formatting, safe links, inline code, lists, blockquotes, images, and code blocks in footnote bodies are rendered where the DOCX footnote model supports them. Tables inside footnote definitions are flattened to plain ` | `-separated text rows, and nested footnote references inside footnote bodies are kept as literal `[^id]` text. Unresolved references are also kept as literal text so they remain visible in the output.
 
 ## API reference
 
@@ -561,7 +571,7 @@ cd md-to-docx
 npm install
 
 npm run build   # compile TypeScript to dist/
-npm test        # run the Jest suite (4 suites, 45 tests)
+npm test        # run the Jest suite
 ```
 
 Tests run offline against generated Word XML using JSZip. Set `DEBUG_DOCX=1` to have tests also write `.docx` artifacts under `test-output/` for manual inspection.

--- a/src/docxModel.ts
+++ b/src/docxModel.ts
@@ -14,15 +14,23 @@ export interface DocxTextNode {
   link?: string;
 }
 
+export interface DocxFootnoteReferenceNode {
+  type: "footnoteReference";
+  identifier: string;
+  id: number;
+}
+
+export type DocxInlineNode = DocxTextNode | DocxFootnoteReferenceNode;
+
 export interface DocxParagraphNode {
   type: "paragraph";
-  children: DocxTextNode[];
+  children: DocxInlineNode[];
 }
 
 export interface DocxHeadingNode {
   type: "heading";
   level: number;
-  children: DocxTextNode[];
+  children: DocxInlineNode[];
 }
 
 export interface DocxListItemNode {
@@ -56,8 +64,8 @@ export interface DocxImageNode {
 
 export interface DocxTableNode {
   type: "table";
-  headers: DocxTextNode[][];
-  rows: DocxTextNode[][][];
+  headers: DocxInlineNode[][];
+  rows: DocxInlineNode[][][];
   align?: (string | null)[];
 }
 
@@ -74,6 +82,12 @@ export interface DocxTocPlaceholderNode {
   type: "tocPlaceholder";
 }
 
+export interface DocxFootnoteDefinitionNode {
+  identifier: string;
+  id: number;
+  children: DocxBlockNode[];
+}
+
 export type DocxBlockNode =
   | DocxParagraphNode
   | DocxHeadingNode
@@ -88,4 +102,5 @@ export type DocxBlockNode =
 
 export interface DocxDocumentModel {
   children: DocxBlockNode[];
+  footnotes?: DocxFootnoteDefinitionNode[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,8 +139,10 @@ export async function parseToDocxOptions(
       style: Style;
       config: SectionConfig;
     }[] = [];
+    const footnotes: Record<string, { children: Paragraph[] }> = {};
     const headings: TocHeadingEntry[] = [];
     let maxSequenceId = 0;
+    let maxFootnoteId = 0;
     const processedImageCounter = { count: 0 };
     const failedRemoteImageCounter = { count: 0 };
     const headingBookmarkCounter = { count: 0 };
@@ -173,9 +175,14 @@ export async function parseToDocxOptions(
         headingBookmarkCounter,
         tocPlaceholders,
         tableWidthTwips: getSectionContentWidthTwips(section.config),
+        footnoteIdOffset: maxFootnoteId,
       });
 
       maxSequenceId = Math.max(maxSequenceId, renderedModel.maxSequenceId);
+      for (const [id, footnote] of Object.entries(renderedModel.footnotes)) {
+        footnotes[id] = footnote;
+        maxFootnoteId = Math.max(maxFootnoteId, Number(id));
+      }
       headings.push(...renderedModel.headings);
 
       renderedSections.push({
@@ -240,6 +247,7 @@ export async function parseToDocxOptions(
         config: numberingConfigs,
       },
       sections: docSections,
+      ...(Object.keys(footnotes).length > 0 ? { footnotes } : {}),
       styles: {
         paragraphStyles: buildParagraphStyles(style),
       },

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -16,14 +16,21 @@ import type {
   InlineCode,
   Link,
   Delete,
+  FootnoteDefinition,
+  FootnoteReference,
 } from "mdast";
 import type {
   DocxDocumentModel,
   DocxBlockNode,
-  DocxTextNode,
+  DocxInlineNode,
   DocxListItemNode,
+  DocxFootnoteDefinitionNode,
 } from "./docxModel.js";
 import { Style, Options } from "./types.js";
+
+interface ProcessOptions {
+  allowFootnoteReferences?: boolean;
+}
 
 /**
  * Classifies a raw HTML node value into a comment or page-break block, or
@@ -53,25 +60,62 @@ export function mdastToDocxModel(
   _options: Options,
 ): DocxDocumentModel {
   const children: DocxBlockNode[] = [];
+  const footnoteDefinitions = new Map<string, FootnoteDefinition>();
+  const referencedFootnoteIds = new Map<string, number>();
   let numberedListSequenceId = 0;
   const listSequenceMap = new Map<List, number>();
 
-  function processNode(node: Node): DocxBlockNode | DocxBlockNode[] | null {
+  for (const child of root.children) {
+    if (child.type === "footnoteDefinition") {
+      const definition = child as FootnoteDefinition;
+      footnoteDefinitions.set(
+        normalizeFootnoteIdentifier(definition.identifier),
+        definition,
+      );
+    }
+  }
+
+  function normalizeFootnoteIdentifier(identifier: string): string {
+    return identifier.trim().toLowerCase();
+  }
+
+  function footnoteLabel(
+    node: Pick<FootnoteReference | FootnoteDefinition, "identifier" | "label">,
+  ): string {
+    return node.label || node.identifier;
+  }
+
+  function footnoteReferenceId(identifier: string): number {
+    const normalizedIdentifier = normalizeFootnoteIdentifier(identifier);
+    const existingId = referencedFootnoteIds.get(normalizedIdentifier);
+    if (existingId) {
+      return existingId;
+    }
+
+    const id = referencedFootnoteIds.size + 1;
+    referencedFootnoteIds.set(normalizedIdentifier, id);
+    return id;
+  }
+
+  function processNode(
+    node: Node,
+    options: ProcessOptions = {},
+  ): DocxBlockNode | DocxBlockNode[] | null {
     switch (node.type) {
       case "heading":
-        return processHeading(node as Heading);
+        return processHeading(node as Heading, options);
       case "paragraph":
-        return processParagraph(node as Paragraph);
+        return processParagraph(node as Paragraph, options);
       case "list":
-        return processList(node as List);
+        return processList(node as List, options);
       case "code":
         return processCodeBlock(node as Code);
       case "blockquote":
-        return processBlockquote(node as Blockquote);
+        return processBlockquote(node as Blockquote, options);
       case "image":
         return processImage(node as Image);
       case "table":
-        return processTable(node as Table);
+        return processTable(node as Table, options);
       case "html":
         return classifyHtmlNode((node as { value?: string }).value || "");
       case "thematicBreak":
@@ -82,8 +126,11 @@ export function mdastToDocxModel(
     }
   }
 
-  function processHeading(heading: Heading): DocxBlockNode {
-    const children = processInlineNodes(heading.children);
+  function processHeading(
+    heading: Heading,
+    options: ProcessOptions = {},
+  ): DocxBlockNode {
+    const children = processInlineNodes(heading.children, options);
     return {
       type: "heading",
       level: heading.depth,
@@ -93,6 +140,7 @@ export function mdastToDocxModel(
 
   function processParagraph(
     paragraph: Paragraph,
+    options: ProcessOptions = {},
   ): DocxBlockNode | DocxBlockNode[] {
     // If the paragraph consists of a single image, treat it as a block image
     if (
@@ -118,7 +166,7 @@ export function mdastToDocxModel(
 
         blocks.push({
           type: "paragraph",
-          children: processInlineNodes(inlineBuffer),
+          children: processInlineNodes(inlineBuffer, options),
         });
         inlineBuffer = [];
       };
@@ -142,14 +190,17 @@ export function mdastToDocxModel(
     }
 
     // Regular paragraph with inline content
-    const children = processInlineNodes(paragraph.children);
+    const children = processInlineNodes(paragraph.children, options);
     return {
       type: "paragraph",
       children,
     };
   }
 
-  function processList(list: List): DocxBlockNode {
+  function processList(
+    list: List,
+    options: ProcessOptions = {},
+  ): DocxBlockNode {
     // Assign sequence ID for numbered lists
     if (list.ordered && !listSequenceMap.has(list)) {
       numberedListSequenceId++;
@@ -164,12 +215,15 @@ export function mdastToDocxModel(
       for (const child of item.children) {
         if (child.type === "list") {
           // Nested list - process recursively
-          const nestedList = processList(child as List);
+          const nestedList = processList(child as List, options);
           if (nestedList) {
             itemChildren.push(nestedList);
           }
         } else if (child.type === "paragraph") {
-          const processedParagraph = processParagraph(child as Paragraph);
+          const processedParagraph = processParagraph(
+            child as Paragraph,
+            options,
+          );
           if (Array.isArray(processedParagraph)) {
             itemChildren.push(...processedParagraph);
           } else {
@@ -177,7 +231,7 @@ export function mdastToDocxModel(
           }
         } else {
           // Other block content (headings, code blocks, etc.)
-          const processed = processNode(child);
+          const processed = processNode(child, options);
           if (processed) {
             if (Array.isArray(processed)) {
               itemChildren.push(...processed);
@@ -218,10 +272,13 @@ export function mdastToDocxModel(
     };
   }
 
-  function processBlockquote(blockquote: Blockquote): DocxBlockNode {
+  function processBlockquote(
+    blockquote: Blockquote,
+    options: ProcessOptions = {},
+  ): DocxBlockNode {
     const children: DocxBlockNode[] = [];
     for (const child of blockquote.children) {
-      const processed = processNode(child);
+      const processed = processNode(child, options);
       if (processed) {
         if (Array.isArray(processed)) {
           children.push(...processed);
@@ -244,21 +301,24 @@ export function mdastToDocxModel(
     };
   }
 
-  function processTable(table: Table): DocxBlockNode {
-    const headers: DocxTextNode[][] = [];
-    const rows: DocxTextNode[][][] = [];
+  function processTable(
+    table: Table,
+    options: ProcessOptions = {},
+  ): DocxBlockNode {
+    const headers: DocxInlineNode[][] = [];
+    const rows: DocxInlineNode[][][] = [];
 
     if (table.children.length > 0) {
       const headerRow = table.children[0] as TableRow;
       for (const cell of headerRow.children) {
-        headers.push(extractRichTextFromTableCell(cell as TableCell));
+        headers.push(extractRichTextFromTableCell(cell as TableCell, options));
       }
 
       for (let i = 1; i < table.children.length; i++) {
         const row = table.children[i] as TableRow;
-        const rowData: DocxTextNode[][] = [];
+        const rowData: DocxInlineNode[][] = [];
         for (const cell of row.children) {
-          rowData.push(extractRichTextFromTableCell(cell as TableCell));
+          rowData.push(extractRichTextFromTableCell(cell as TableCell, options));
         }
         rows.push(rowData);
       }
@@ -272,20 +332,27 @@ export function mdastToDocxModel(
     };
   }
 
-  function extractRichTextFromTableCell(cell: TableCell): DocxTextNode[] {
-    const nodes: DocxTextNode[] = [];
+  function extractRichTextFromTableCell(
+    cell: TableCell,
+    options: ProcessOptions = {},
+  ): DocxInlineNode[] {
+    const nodes: DocxInlineNode[] = [];
     for (const child of cell.children as any[]) {
       if (child.type === "paragraph") {
-        nodes.push(...processInlineNodes(child.children));
+        nodes.push(...processInlineNodes(child.children, options));
       } else {
-        nodes.push(...processInlineNodes([child]));
+        nodes.push(...processInlineNodes([child], options));
       }
     }
     return nodes;
   }
 
-  function processInlineNodes(nodes: any[]): DocxTextNode[] {
-    const result: DocxTextNode[] = [];
+  function processInlineNodes(
+    nodes: any[],
+    options: ProcessOptions = {},
+  ): DocxInlineNode[] {
+    const result: DocxInlineNode[] = [];
+    const allowFootnoteReferences = options.allowFootnoteReferences ?? true;
 
     function pushTextWithUnderline(value: string): void {
       const parts = value.split(/(\+\+[^+\n][\s\S]*?\+\+)/g);
@@ -313,32 +380,36 @@ export function mdastToDocxModel(
         case "emphasis": {
           const emphasisChildren = processInlineNodes(
             (node as Emphasis).children,
+            options,
           );
           for (const child of emphasisChildren) {
-            result.push({
-              ...child,
-              italic: true,
-            });
+            result.push(
+              child.type === "text" ? { ...child, italic: true } : child,
+            );
           }
           break;
         }
         case "strong": {
-          const strongChildren = processInlineNodes((node as Strong).children);
+          const strongChildren = processInlineNodes(
+            (node as Strong).children,
+            options,
+          );
           for (const child of strongChildren) {
-            result.push({
-              ...child,
-              bold: true,
-            });
+            result.push(child.type === "text" ? { ...child, bold: true } : child);
           }
           break;
         }
         case "delete": {
-          const strikeChildren = processInlineNodes((node as Delete).children);
+          const strikeChildren = processInlineNodes(
+            (node as Delete).children,
+            options,
+          );
           for (const child of strikeChildren) {
-            result.push({
-              ...child,
-              strikethrough: true,
-            });
+            result.push(
+              child.type === "text"
+                ? { ...child, strikethrough: true }
+                : child,
+            );
           }
           break;
         }
@@ -361,11 +432,33 @@ export function mdastToDocxModel(
             previous.value += (node as Link).url;
             break;
           }
-          const linkChildren = processInlineNodes((node as Link).children);
+          const linkChildren = processInlineNodes((node as Link).children, options);
           for (const child of linkChildren) {
+            result.push(
+              child.type === "text" ? { ...child, link: (node as Link).url } : child,
+            );
+          }
+          break;
+        }
+        case "footnoteReference": {
+          const footnoteReference = node as FootnoteReference;
+          const normalizedIdentifier = normalizeFootnoteIdentifier(
+            footnoteReference.identifier,
+          );
+
+          if (
+            allowFootnoteReferences &&
+            footnoteDefinitions.has(normalizedIdentifier)
+          ) {
             result.push({
-              ...child,
-              link: (node as Link).url,
+              type: "footnoteReference",
+              identifier: normalizedIdentifier,
+              id: footnoteReferenceId(normalizedIdentifier),
+            });
+          } else {
+            result.push({
+              type: "text",
+              value: `[^${footnoteLabel(footnoteReference)}]`,
             });
           }
           break;
@@ -388,6 +481,53 @@ export function mdastToDocxModel(
     }
 
     return result;
+  }
+
+  function processFootnoteDefinition(
+    definition: FootnoteDefinition,
+    id: number,
+  ): DocxFootnoteDefinitionNode {
+    const footnoteChildren: DocxBlockNode[] = [];
+
+    for (const child of definition.children) {
+      const processed = processFootnoteDefinitionChild(child);
+      if (processed) {
+        if (Array.isArray(processed)) {
+          footnoteChildren.push(...processed);
+        } else {
+          footnoteChildren.push(processed);
+        }
+      }
+    }
+
+    if (footnoteChildren.length === 0) {
+      footnoteChildren.push({
+        type: "paragraph",
+        children: [],
+      });
+    }
+
+    return {
+      identifier: normalizeFootnoteIdentifier(definition.identifier),
+      id,
+      children: footnoteChildren,
+    };
+  }
+
+  function processFootnoteDefinitionChild(
+    node: Node,
+  ): DocxBlockNode | DocxBlockNode[] | null {
+    if (node.type === "paragraph") {
+      const paragraph = node as Paragraph;
+      return {
+        type: "paragraph",
+        children: processInlineNodes(paragraph.children, {
+          allowFootnoteReferences: false,
+        }),
+      };
+    }
+
+    return processNode(node, { allowFootnoteReferences: false });
   }
 
   // Process root children
@@ -422,6 +562,10 @@ export function mdastToDocxModel(
       continue;
     }
 
+    if (child.type === "footnoteDefinition") {
+      continue;
+    }
+
     const processed = processNode(child);
     if (processed) {
       if (Array.isArray(processed)) {
@@ -432,5 +576,10 @@ export function mdastToDocxModel(
     }
   }
 
-  return { children };
+  const footnotes = Array.from(referencedFootnoteIds.entries()).map(
+    ([identifier, id]) =>
+      processFootnoteDefinition(footnoteDefinitions.get(identifier)!, id),
+  );
+
+  return { children, footnotes };
 }

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -5,17 +5,19 @@ import {
   TableCell,
   TextRun,
   ExternalHyperlink,
+  FootnoteReferenceRun,
   PageBreak,
   AlignmentType,
   TableLayoutType,
   WidthType,
 } from "docx";
-import type { IParagraphOptions } from "docx";
+import type { IParagraphOptions, ParagraphChild } from "docx";
 import type {
   DocxDocumentModel,
   DocxBlockNode,
   DocxListNode,
   DocxListItemNode,
+  DocxInlineNode,
   DocxTextNode,
 } from "./docxModel.js";
 import { Style, Options } from "./types.js";
@@ -42,6 +44,7 @@ interface InlineOverrides {
 
 interface RenderContext {
   quoteLevel?: number;
+  inFootnote?: boolean;
 }
 
 interface ListMarkerContext {
@@ -93,16 +96,20 @@ export async function modelToDocx(
      * avoiding the percentage form that Word 2007 treats as corrupt.
      */
     tableWidthTwips?: number;
+    /** Offset applied so footnote IDs remain unique across sections. */
+    footnoteIdOffset?: number;
   } = {},
 ): Promise<{
   children: (Paragraph | Table)[];
   headings: { text: string; level: number; bookmarkId: string }[];
   maxSequenceId: number;
+  footnotes: Record<string, { children: Paragraph[] }>;
 }> {
   const children: (Paragraph | Table)[] = [];
   const headings: { text: string; level: number; bookmarkId: string }[] = [];
   const documentType = options.documentType || "document";
   const sequenceIdOffset = renderOptions.sequenceIdOffset || 0;
+  const footnoteIdOffset = renderOptions.footnoteIdOffset || 0;
   const imageHandling = resolveImageHandlingOptions(options.imageHandling);
   const processedImageCounter = renderOptions.processedImageCounter ?? {
     count: 0,
@@ -144,12 +151,14 @@ export async function modelToDocx(
   }
 
   function renderInlineNodes(
-    nodes: DocxTextNode[],
+    nodes: DocxInlineNode[],
     overrides: InlineOverrides = {},
-  ): (TextRun | ExternalHyperlink)[] {
-    const out: (TextRun | ExternalHyperlink)[] = [];
+  ): ParagraphChild[] {
+    const out: ParagraphChild[] = [];
     for (const node of nodes) {
-      if (node.link && !isSafeLinkUrl(node.link)) {
+      if (node.type === "footnoteReference") {
+        out.push(new FootnoteReferenceRun(node.id + footnoteIdOffset));
+      } else if (node.link && !isSafeLinkUrl(node.link)) {
         out.push(textRunFromNode({ ...node, link: undefined }, overrides));
       } else if (node.link) {
         out.push(
@@ -182,7 +191,7 @@ export async function modelToDocx(
   }
 
   function paragraphFromInlineNodes(
-    nodes: DocxTextNode[],
+    nodes: DocxInlineNode[],
     context: RenderContext = {},
     overrides: InlineOverrides = {},
   ): Paragraph {
@@ -274,7 +283,7 @@ export async function modelToDocx(
   }
 
   function listParagraphFromInlineNodes(
-    nodes: DocxTextNode[],
+    nodes: DocxInlineNode[],
     isOrdered: boolean,
     level: number,
     sequenceId: number | undefined,
@@ -310,7 +319,7 @@ export async function modelToDocx(
   }
 
   function listContinuationParagraphFromInlineNodes(
-    nodes: DocxTextNode[],
+    nodes: DocxInlineNode[],
     level: number,
     context: RenderContext = {},
   ): Paragraph {
@@ -332,6 +341,17 @@ export async function modelToDocx(
     });
   }
 
+  function textFromInlineNodes(nodes: DocxInlineNode[]): string {
+    return nodes
+      .map((node) => {
+        if (node.type === "text") {
+          return node.value;
+        }
+        return "";
+      })
+      .join("");
+  }
+
   async function renderBlockNode(
     node: DocxBlockNode,
     listLevel: number = 0,
@@ -341,7 +361,11 @@ export async function modelToDocx(
 
     switch (node.type) {
       case "heading": {
-        const headingText = node.children.map((c) => c.value).join("");
+        if (context.inFootnote) {
+          return [paragraphFromInlineNodes(node.children, context)];
+        }
+
+        const headingText = textFromInlineNodes(node.children);
         headingBookmarkCounter.count++;
         const bookmarkId = `_Toc_${sanitizeForBookmarkId(headingText)}_${headingBookmarkCounter.count}`;
         const { paragraph } = processHeading(
@@ -430,7 +454,10 @@ export async function modelToDocx(
   ): Promise<(Paragraph | Table)[]> {
     throwIfAborted(options.signal);
 
-    const quoteContext = { quoteLevel: (context.quoteLevel || 0) + 1 };
+    const quoteContext = {
+      ...context,
+      quoteLevel: (context.quoteLevel || 0) + 1,
+    };
     const out: (Paragraph | Table)[] = [];
 
     if (node.children.length === 0) {
@@ -693,6 +720,75 @@ export async function modelToDocx(
     }
   }
 
+  function footnoteFallbackParagraph(text: string): Paragraph {
+    return paragraphFromInlineNodes([
+      {
+        type: "text",
+        value: text,
+        italic: true,
+      },
+    ]);
+  }
+
+  function tableFootnoteFallbackParagraphs(
+    node: Extract<DocxBlockNode, { type: "table" }>,
+  ): Paragraph[] {
+    const rows = [node.headers, ...node.rows];
+    return rows.map((row) =>
+      paragraphFromInlineNodes([
+        {
+          type: "text",
+          value: row.map((cell) => textFromInlineNodes(cell)).join(" | "),
+        },
+      ]),
+    );
+  }
+
+  async function renderFootnoteBlockNode(
+    node: DocxBlockNode,
+  ): Promise<Paragraph[]> {
+    if (node.type === "table") {
+      return tableFootnoteFallbackParagraphs(node);
+    }
+
+    const rendered = await renderBlockNode(node, 0, { inFootnote: true });
+    const paragraphs: Paragraph[] = [];
+
+    for (const child of rendered) {
+      if (child instanceof Paragraph) {
+        paragraphs.push(child);
+      } else {
+        paragraphs.push(
+          footnoteFallbackParagraph("[Unsupported footnote content omitted]"),
+        );
+      }
+    }
+
+    return paragraphs;
+  }
+
+  async function renderFootnotes(): Promise<
+    Record<string, { children: Paragraph[] }>
+  > {
+    const footnotes: Record<string, { children: Paragraph[] }> = {};
+
+    for (const footnote of model.footnotes ?? []) {
+      const footnoteChildren: Paragraph[] = [];
+      for (const child of footnote.children) {
+        footnoteChildren.push(...(await renderFootnoteBlockNode(child)));
+      }
+
+      footnotes[String(footnote.id + footnoteIdOffset)] = {
+        children:
+          footnoteChildren.length > 0
+            ? footnoteChildren
+            : [paragraphFromInlineNodes([])],
+      };
+    }
+
+    return footnotes;
+  }
+
   // Process all top-level nodes
   let previousNodeType: string | undefined;
   for (const node of model.children) {
@@ -712,5 +808,10 @@ export async function modelToDocx(
     previousNodeType = node.type;
   }
 
-  return { children, headings, maxSequenceId };
+  return {
+    children,
+    headings,
+    maxSequenceId,
+    footnotes: await renderFootnotes(),
+  };
 }

--- a/src/renderers/headingRenderer.ts
+++ b/src/renderers/headingRenderer.ts
@@ -1,13 +1,12 @@
 import {
   Paragraph,
-  TextRun,
-  ExternalHyperlink,
   HeadingLevel,
   AlignmentType,
   Bookmark,
 } from "docx";
+import type { ParagraphChild } from "docx";
 import { Style, AlignmentOption } from "../types.js";
-import type { DocxTextNode } from "../docxModel.js";
+import type { DocxInlineNode } from "../docxModel.js";
 
 /**
  * Resolves the font size (in half-points) for a heading level, honouring
@@ -54,13 +53,13 @@ function resolveHeadingAlignment(
  * @returns The heading paragraph and its bookmark id
  */
 export function processHeading(
-  children: DocxTextNode[],
+  children: DocxInlineNode[],
   config: { level: number; bookmarkId: string },
   style: Style,
   renderInline: (
-    nodes: DocxTextNode[],
+    nodes: DocxInlineNode[],
     size: number
-  ) => (TextRun | ExternalHyperlink)[]
+  ) => ParagraphChild[]
 ): { paragraph: Paragraph; bookmarkId: string } {
   const headingLevel = config.level;
   const headingSize = resolveHeadingSize(headingLevel, style);

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -228,6 +228,112 @@ describe("Rendering: inline formatting", () => {
   });
 });
 
+describe("Rendering: footnotes", () => {
+  it("renders a basic Markdown footnote as native DOCX footnote markup", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Text with a footnote[^1].\n\n[^1]: Footnote body.",
+    );
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const footnotesXml = await zip.file("word/footnotes.xml")?.async("string");
+
+    expect(documentXml).toContain("<w:footnoteReference");
+    expect(documentXml).toContain('w:id="1"');
+    expect(documentXml).not.toContain("Footnote body.");
+    expect(footnotesXml).toBeDefined();
+    expect(footnotesXml).toContain('<w:footnote w:id="1"');
+    expect(footnotesXml).toContain("Footnote body.");
+  });
+
+  it("preserves inline formatting, links, and code inside footnote content", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Formatted note[^fmt].\n\n[^fmt]: **bold**, *italic*, [link](https://example.com/fn), and `code`.",
+    );
+    const zip = await getZip(blob);
+    const footnotesXml = await zip.file("word/footnotes.xml")!.async("string");
+    const footnoteRels = await zip
+      .file("word/_rels/footnotes.xml.rels")
+      ?.async("string");
+
+    expect(footnotesXml).toContain("bold");
+    expect(footnotesXml).toContain("italic");
+    expect(footnotesXml).toContain("code");
+    expect(footnotesXml).toMatch(/<w:b\/>(?:(?!<\/w:r>)[\s\S])*?>bold<\/w:t>/);
+    expect(footnotesXml).toMatch(/<w:i\/>(?:(?!<\/w:r>)[\s\S])*?>italic<\/w:t>/);
+    expect(footnotesXml).toContain("<w:hyperlink");
+    expect(footnotesXml).toContain('w:ascii="Courier New"');
+    expect(footnoteRels).toContain("https://example.com/fn");
+  });
+
+  it("handles multiple footnotes and repeated references deterministically", async () => {
+    const blob = await convertMarkdownToDocx(
+      "First[^alpha], second[^beta], first again[^alpha].\n\n[^beta]: Beta body.\n[^alpha]: Alpha body.",
+    );
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const footnotesXml = await zip.file("word/footnotes.xml")!.async("string");
+
+    expect(
+      Array.from(
+        documentXml.matchAll(/<w:footnoteReference w:id="(\d+)"\/>/g),
+        (match) => match[1],
+      ),
+    ).toEqual(["1", "2", "1"]);
+    expect(footnotesXml.indexOf('w:id="1"')).toBeLessThan(
+      footnotesXml.indexOf('w:id="2"'),
+    );
+    expect(footnotesXml.indexOf("Alpha body.")).toBeLessThan(
+      footnotesXml.indexOf("Beta body."),
+    );
+  });
+
+  it("keeps unresolved footnote references as literal text", async () => {
+    const xml = await render("Missing note[^missing] stays visible.");
+
+    expect(xml).toContain("[^missing]");
+    expect(xml).not.toContain("<w:footnoteReference");
+  });
+
+  it("keeps nested footnote references inside footnote content as literal text", async () => {
+    const blob = await convertMarkdownToDocx(
+      "Outer note[^outer].\n\n[^outer]: Nested reference [^inner] stays visible.\n[^inner]: Inner body.",
+    );
+    const zip = await getZip(blob);
+    const footnotesXml = await zip.file("word/footnotes.xml")!.async("string");
+
+    expect(footnotesXml).toContain("Nested reference ");
+    expect(footnotesXml).toContain("[^inner]");
+    expect(footnotesXml).not.toContain("Inner body.");
+  });
+
+  it("keeps footnote IDs unique across sections", async () => {
+    const blob = await convertMarkdownToDocx("", {
+      sections: [
+        {
+          markdown: "Section one[^one].\n\n[^one]: First section footnote.",
+        },
+        {
+          markdown: "Section two[^two].\n\n[^two]: Second section footnote.",
+        },
+      ],
+    });
+    const zip = await getZip(blob);
+    const documentXml = await zip.file("word/document.xml")!.async("string");
+    const footnotesXml = await zip.file("word/footnotes.xml")!.async("string");
+
+    expect(
+      Array.from(
+        documentXml.matchAll(/<w:footnoteReference w:id="(\d+)"\/>/g),
+        (match) => match[1],
+      ),
+    ).toEqual(["1", "2"]);
+    expect(footnotesXml).toContain('<w:footnote w:id="1"');
+    expect(footnotesXml).toContain('<w:footnote w:id="2"');
+    expect(footnotesXml).toContain("First section footnote.");
+    expect(footnotesXml).toContain("Second section footnote.");
+  });
+});
+
 describe("Rendering: lists", () => {
   it("renders bullet and numbered lists with numbering references", async () => {
     const markdown = `## Bullets


### PR DESCRIPTION
## Summary
- Adds native DOCX footnote references and footnote definitions for GFM/remark Markdown footnotes.
- Preserves supported inline formatting inside footnote content and keeps unresolved/nested footnote references visible as literal text.
- Documents supported footnote syntax and deterministic limits, including table flattening inside footnotes.

## Shared files touched
- `src/docxModel.ts`, `src/mdastToDocxModel.ts`, `src/modelToDocx.ts`, `src/renderers/headingRenderer.ts`, and `src/index.ts` were updated because footnotes cross the parser/model/rendering/Document-options boundary.

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand`

Closes #55

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core AST→model→DOCX pipeline and document-level footnote aggregation across sections, though behavior is covered by XML-level tests and preserves literal text for unresolved/nested refs.
> 
> **Overview**
> Adds **GFM/remark footnotes** (`[^ref]` + `[^ref]: body`) through the full conversion path so the main document gets native `w:footnoteReference` runs and bodies land in `word/footnotes.xml`.
> 
> The internal model now carries **footnote reference inline nodes** (not only text) in paragraphs, headings, and table cells; referenced definitions are collected at parse time, ordered by first use, and merged into the final `Document` options in `parseToDocxOptions`, with **per-section ID offsets** so multi-section templates do not collide.
> 
> Footnote bodies reuse the block renderer with constraints: **nested footnote refs** and **missing definitions** stay as literal `[^id]` text; **tables** in definitions flatten to ` | `-separated lines; unsupported blocks get a short fallback paragraph. README documents syntax and limits; **rendering tests** assert XML for basic notes, formatting/links, repeats, and cross-section IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52769c75681d419dfa932eb47aac973efc091af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete footnote support. Markdown footnotes now render as native DOCX footnotes with full inline formatting preservation (bold, italic, links, code) and proper cross-references across multiple sections.

* **Documentation**
  * Updated documentation with footnote syntax and supported features.

* **Tests**
  * Added comprehensive test suite covering footnote rendering, formatting, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->