### PR TITLE
feat: render GFM task lists and thematic breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GFM task-list rendering with deterministic Unicode unchecked (`☐`) and checked (`☒`) markers while preserving Word list nesting and inline formatting.
+- Markdown thematic breaks (`---`, `***`, and `___`) rendered as native Word paragraph borders, including supported nested blockquote and list contexts.
+
 ## [2.10.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -577,16 +577,23 @@ await convertMarkdownToDocx(markdown, {
 | Mermaid diagrams  | `````mermaid                   | Opt-in image rendering; code fallback                |
 | Chart blocks      | `````chart / chartjs           | Opt-in PNG rendering; Chart.js-like JSON subset      |
 | Lists             | `-`, `*`, `1.`                 | Bullet, numbered, nested, rich formatting inside     |
+| Task lists        | `- [ ]`, `- [x]`, `- [X]`     | GFM; unchecked `☐`, checked `☒`; preserves nesting   |
 | Tables            | `\| a \| b \|`                 | GFM tables                                           |
 | Blockquotes       | `> text`                       |                                                      |
 | Callouts          | `> [!NOTE]`                    | GitHub-style callout blocks                          |
 | Links             | `[text](url)`                  |                                                      |
 | Images            | `![alt](url)`                  | HTTP(S) and `data:` URLs; supports `#w=...&h=...` sizing |
 | Footnotes         | `Text[^1]` + `[^1]: Note text` | Native Word footnotes                                |
-| Horizontal rule   | `---`                          | Skipped during conversion                            |
+| Horizontal rule   | `---`, `***`, `___`            | Native Word paragraph border                         |
 | Table of Contents | `[TOC]`                        | Clickable, auto-populated                            |
 | Page break        | `\pagebreak`                   | Place on its own line                                |
 | Comments          | `<!-- COMMENT: text -->`       | Rendered as Word comments                            |
+
+Task-list checkboxes use Unicode ballot-box text (`☐` U+2610 and `☒` U+2612)
+inside the existing Word list paragraph. This deterministic representation has
+no form controls, macros, or font-specific Wingdings encoding, so task items
+retain normal bullet/number markers, nesting, and inline formatting across DOCX
+readers. The checkboxes are display-only, not interactive controls.
 
 Markdown footnotes use the GFM/remark syntax:
 

--- a/src/docxModel.ts
+++ b/src/docxModel.ts
@@ -44,6 +44,8 @@ export interface DocxHeadingNode {
 export interface DocxListItemNode {
   type: "listItem";
   children: DocxBlockNode[];
+  /** GFM task state; undefined means this is an ordinary list item. */
+  checked?: boolean;
 }
 
 export interface DocxListNode {
@@ -115,6 +117,10 @@ export interface DocxTocPlaceholderNode {
   type: "tocPlaceholder";
 }
 
+export interface DocxHorizontalRuleNode {
+  type: "horizontalRule";
+}
+
 export interface DocxFootnoteDefinitionNode {
   identifier: string;
   id: number;
@@ -134,6 +140,7 @@ export type DocxBlockNode =
   | DocxTableNode
   | DocxCommentNode
   | DocxPageBreakNode
+  | DocxHorizontalRuleNode
   | DocxTocPlaceholderNode;
 
 export interface DocxDocumentModel {

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -162,8 +162,7 @@ export function mdastToDocxModel(
       case "html":
         return classifyHtmlNode((node as { value?: string }).value || "");
       case "thematicBreak":
-        // Horizontal rule - skip for now
-        return null;
+        return { type: "horizontalRule" };
       default:
         return null;
     }
@@ -296,6 +295,8 @@ export function mdastToDocxModel(
       listItems.push({
         type: "listItem",
         children: itemChildren,
+        checked:
+          typeof item.checked === "boolean" ? item.checked : undefined,
       });
     }
 

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -37,6 +37,7 @@ import {
 import { processChartBlock } from "./renderers/chartRenderer.js";
 import { parseTexMath, renderNativeMath } from "./renderers/mathRenderer.js";
 import { processInlineCode } from "./renderers/textRenderer.js";
+import { processHorizontalRule } from "./renderers/horizontalRuleRenderer.js";
 import { resolveFontFamily } from "./utils/styleUtils.js";
 import { sanitizeForBookmarkId } from "./utils/bookmarkUtils.js";
 import { throwIfAborted } from "./processingLimits.js";
@@ -60,7 +61,13 @@ interface ListMarkerContext {
   isOrdered: boolean;
   level: number;
   sequenceId: number | undefined;
+  taskChecked?: boolean;
 }
+
+const TASK_MARKERS = {
+  unchecked: "\u2610 ",
+  checked: "\u2612 ",
+} as const;
 
 const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
@@ -327,6 +334,7 @@ export async function modelToDocx(
     level: number,
     sequenceId: number | undefined,
     context: RenderContext = {},
+    taskChecked?: boolean,
   ): Paragraph {
     const quoteStyle = context.quoteLevel
       ? blockquoteParagraphStyle(
@@ -336,7 +344,20 @@ export async function modelToDocx(
         )
       : undefined;
     const base = {
-      children: renderInlineNodes(nodes, { size: style.listItemSize || 24 }),
+      children: renderInlineNodes(
+        taskChecked === undefined
+          ? nodes
+          : [
+              {
+                type: "text",
+                value: taskChecked
+                  ? TASK_MARKERS.checked
+                  : TASK_MARKERS.unchecked,
+              },
+              ...nodes,
+            ],
+        { size: style.listItemSize || 24 },
+      ),
       spacing: {
         before: style.paragraphSpacing / 2,
         after: style.paragraphSpacing / 2,
@@ -513,6 +534,17 @@ export async function modelToDocx(
         return [new Paragraph({ children: [new PageBreak()] })];
       }
 
+      case "horizontalRule": {
+        const quoteStyle = context.quoteLevel
+          ? blockquoteParagraphStyle(
+              style,
+              context.quoteLevel,
+              context.calloutType,
+            )
+          : undefined;
+        return [processHorizontalRule(style, quoteStyle)];
+      }
+
       case "tocPlaceholder": {
         const placeholder = new Paragraph({});
         renderOptions.tocPlaceholders?.add(placeholder);
@@ -657,6 +689,7 @@ export async function modelToDocx(
               level,
               sequenceId,
               context,
+              item.checked,
             ),
           );
         } else {
@@ -672,7 +705,12 @@ export async function modelToDocx(
         // Other block types - render normally but they'll appear as part of list item
         const markerContext =
           paragraphs.length === 0
-            ? { isOrdered, level, sequenceId }
+            ? {
+                isOrdered,
+                level,
+                sequenceId,
+                taskChecked: item.checked,
+              }
             : undefined;
         const rendered = await renderBlockNodeWithListMarker(
           child,
@@ -692,7 +730,14 @@ export async function modelToDocx(
     // If no paragraphs were created, create an empty list item
     if (paragraphs.length === 0) {
       paragraphs.push(
-        listParagraphFromInlineNodes([], isOrdered, level, sequenceId, context),
+        listParagraphFromInlineNodes(
+          [],
+          isOrdered,
+          level,
+          sequenceId,
+          context,
+          item.checked,
+        ),
       );
     }
 
@@ -742,6 +787,49 @@ export async function modelToDocx(
     context: RenderContext,
     listMarker?: ListMarkerContext,
   ): Promise<(Paragraph | Table)[]> {
+    if (node.type === "horizontalRule") {
+      const quoteStyle = context.quoteLevel
+        ? blockquoteParagraphStyle(
+            style,
+            context.quoteLevel,
+            context.calloutType,
+          )
+        : undefined;
+      const quoteIndent = quoteStyle?.indent.left ?? 0;
+      return [
+        ...(listMarker
+          ? [
+              listParagraphFromInlineNodes(
+                [],
+                listMarker.isOrdered,
+                listMarker.level,
+                listMarker.sequenceId,
+                context,
+                listMarker.taskChecked,
+              ),
+            ]
+          : []),
+        processHorizontalRule(style, {
+          ...quoteStyle,
+          indent: { left: quoteIndent + 720 * (listLevel + 1) },
+        }),
+      ];
+    }
+
+    if (listMarker?.taskChecked !== undefined) {
+      return [
+        listParagraphFromInlineNodes(
+          [],
+          listMarker.isOrdered,
+          listMarker.level,
+          listMarker.sequenceId,
+          context,
+          listMarker.taskChecked,
+        ),
+        ...(await renderBlockNode(node, listLevel, context)),
+      ];
+    }
+
     if (node.type === "image" || node.type === "chartBlock") {
       return node.type === "image"
         ? renderImageNode(node, context, listMarker)
@@ -761,6 +849,7 @@ export async function modelToDocx(
           listMarker.level,
           listMarker.sequenceId,
           context,
+          listMarker.taskChecked,
         ),
         ...rendered,
       ];

--- a/src/renderers/horizontalRuleRenderer.ts
+++ b/src/renderers/horizontalRuleRenderer.ts
@@ -1,0 +1,33 @@
+import { BorderStyle, Paragraph } from "docx";
+import type { IParagraphOptions } from "docx";
+import type { Style } from "../types.js";
+
+/**
+ * Renders a Markdown thematic break as a paragraph bottom border. Paragraph
+ * borders are native Word markup, resize with the page, and require no fonts
+ * or drawing relationships.
+ */
+export function processHorizontalRule(
+  style: Style,
+  paragraphOptions: Partial<IParagraphOptions> = {},
+): Paragraph {
+  const { border, spacing, ...rest } = paragraphOptions;
+
+  return new Paragraph({
+    ...rest,
+    children: [],
+    spacing: spacing ?? {
+      before: style.paragraphSpacing / 2,
+      after: style.paragraphSpacing / 2,
+    },
+    border: {
+      ...border,
+      bottom: {
+        style: BorderStyle.SINGLE,
+        size: 6,
+        color: "A6A6A6",
+        space: 1,
+      },
+    },
+  });
+}

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -30,6 +30,10 @@ function numberingMarkerCount(xml: string): number {
   return xml.match(/<w:numPr>/g)?.length || 0;
 }
 
+function horizontalRuleCount(xml: string): number {
+  return xml.match(/<w:bottom\b/g)?.length || 0;
+}
+
 function mediaFilesFromZip(zip: Awaited<ReturnType<typeof getZip>>): string[] {
   return Object.entries(zip.files)
     .filter(([p, file]) => p.startsWith("word/media/") && !file.dir)
@@ -563,6 +567,73 @@ Interrupting paragraph.
     expect(xml).toContain("Before ");
     expect(xml).toContain(" after");
     expect(xml).toContain("<w:drawing>");
+    expect(numberingMarkerCount(xml)).toBe(1);
+  });
+
+  it("renders checked, unchecked, and nested GFM task items", async () => {
+    const xml = await render(`- [ ] Pending **bold** work
+- [x] Done *today*
+- [X] Uppercase checked
+  - [ ] Nested \`code\` task`);
+
+    expect(xml.match(/☐/g)).toHaveLength(2);
+    expect(xml.match(/☒/g)).toHaveLength(2);
+    expect(xml).toContain("Pending ");
+    expect(xml).toContain("Nested ");
+    expect(xml).toContain(" task");
+    expect(xml).toContain("<w:b/>");
+    expect(xml).toContain("<w:i/>");
+    expect(xml).toContain('<w:shd w:fill="F5F5F5"/');
+    expect(numberingLevels(xml)).toEqual(["0", "0", "0", "1"]);
+  });
+
+  it("keeps ordinary ordered and unordered list rendering unchanged", async () => {
+    const xml = await render(`- ordinary bullet
+- **formatted** bullet
+
+1. ordinary number
+2. second number`);
+
+    expect(xml).not.toContain("☐");
+    expect(xml).not.toContain("☒");
+    expect(xml).toContain("ordinary bullet");
+    expect(xml).toContain("ordinary number");
+    expect(xml).toContain("<w:b/>");
+    expect(numberingMarkerCount(xml)).toBe(4);
+  });
+});
+
+describe("Rendering: thematic breaks", () => {
+  it.each(["---", "***", "___"])(
+    "renders %s as a native Word horizontal rule",
+    async (marker) => {
+      const xml = await render(`Before\n\n${marker}\n\nAfter`);
+
+      expect(horizontalRuleCount(xml)).toBe(1);
+      expect(xml).toMatch(
+        /<w:bottom w:val="single" w:color="A6A6A6" w:sz="6" w:space="1"\/>/,
+      );
+      expect(xml).toContain("Before");
+      expect(xml).toContain("After");
+    },
+  );
+
+  it("renders thematic breaks inside blockquotes and list items", async () => {
+    const xml = await render(`> Quoted before
+>
+> ***
+>
+> Quoted after
+
+- List item
+
+  ___`);
+
+    expect(horizontalRuleCount(xml)).toBe(2);
+    expect(xml).toMatch(
+      /<w:pBdr><w:bottom\b[^>]*\/><w:left\b[^>]*\/><\/w:pBdr>/,
+    );
+    expect(xml).toContain('<w:ind w:left="720"/>');
     expect(numberingMarkerCount(xml)).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- render GFM task-list items with deterministic Unicode `☐` and `☒` markers while retaining native Word list numbering, nesting, and inline formatting
- render Markdown thematic breaks (`---`, `***`, and `___`) as visible native Word paragraph borders
- cover checked, unchecked, nested, ordinary-list regression, and nested thematic-break behavior at the generated XML level
- document the portable DOCX representation in the README and changelog

## Why

The Markdown AST already exposed task state and thematic-break nodes, but conversion discarded the task state and skipped thematic breaks entirely. This made task items indistinguishable from ordinary list items and removed separators from generated documents.

## User impact

Task lists are now visibly differentiated without macros, form controls, or Wingdings-specific encoding. The markers are display-only and remain compatible with existing ordered/unordered list behavior. Thematic breaks remain visible across standard and supported nested contexts.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` — 179/179 passing
- `npm run test:consumer`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive rendering in the list/HR pipeline with regression tests; no auth, security, or API contract changes.
> 
> **Overview**
> GFM task lists and horizontal rules now survive Markdown→DOCX conversion instead of being dropped or indistinguishable from normal bullets.
> 
> **Task lists** carry `checked` from the AST through the docx model; list paragraphs prepend display-only Unicode markers (`☐` / `☒`) while keeping native bullets/numbers, nesting, and inline formatting. Task items whose first block isn’t a paragraph still get a marker via `renderBlockNodeWithListMarker`.
> 
> **Thematic breaks** (`---`, `***`, `___`) map to a new `horizontalRule` block type and render as empty paragraphs with a bottom border (`horizontalRuleRenderer.ts`), including inside blockquotes and list items (with quote/list indentation). README and changelog document the behavior; XML-level tests cover tasks, ordinary-list regression, and nested rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba72ffb65ac9c7f46021166384dfeffc3fa73ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->