### PR TITLE
feat: add captions and cross-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pandoc-style figure and table captions with document-wide automatic numbering, stable Word bookmarks, native clickable cross-references, multi-section and forward-reference support, typed label/placement/style/failure options, and explicit reference-DOCX patch validation.
+
 ## [2.10.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A TypeScript-first library and CLI that turns Markdown into production-ready Wor
   - [React](#react)
 - [Features](#features)
   - [Multi-section documents (template + sections)](#multi-section-documents-template--sections)
+  - [Figure and table captions](#figure-and-table-captions)
   - [Syntax-highlighted code blocks](#syntax-highlighted-code-blocks)
   - [Chart fenced blocks](#chart-fenced-blocks)
   - [Mermaid diagram blocks](#mermaid-diagram-blocks)
@@ -51,6 +52,7 @@ A TypeScript-first library and CLI that turns Markdown into production-ready Wor
 - **First-class CLI** — `npx @mohtasham/md-to-docx input.md output.docx`.
 - **TypeScript-native** — fully typed options surface, including `CodeHighlightTheme`, `Options`, and `DocumentSection`.
 - **Multi-section documents** — cover pages, per-section headers/footers, page numbering resets, mixed orientations, style overrides.
+- **Captioned figures and tables** — automatic document-wide numbering, stable Word bookmarks, and clickable cross-references.
 - **Reference DOCX patching** — Node-friendly placeholder replacement for inserting generated Markdown into an existing `.docx` package.
 - **Optional syntax highlighting** — opt-in, powered by `[lowlight](https://github.com/wooorm/lowlight)`; ships a GitHub-light theme and lets you override any token color.
 - **Native Word math** — Markdown `$...$` and `$$...$$` equations render as editable Word math for a documented TeX subset.
@@ -244,6 +246,51 @@ const blob = await convertMarkdownToDocx("", {
 
 **Precedence (last wins):** global `style` → `template.style` → per-section `style`. For `headers` / `footers`, each slot (`default`, `first`, `even`) can inherit, override, or be explicitly disabled with `null`.
 
+### Figure and table captions
+
+Use a Pandoc-style caption paragraph immediately after a standalone image or GFM table. Leave a blank line before the caption paragraph, start it with `: `, and finish it with a kind-prefixed identifier. Reference the identifier with pandoc-crossref-style `[@fig:id]` or `[@tbl:id]` syntax:
+
+```markdown
+The architecture is shown in [@fig:architecture]. Results are in [@tbl:results].
+
+![Accessible architecture diagram](architecture.png)
+
+: System *architecture* {#fig:architecture}
+
+| Metric | Value |
+| --- | ---: |
+| Accuracy | 98% |
+
+: **Evaluation** results {#tbl:results}
+```
+
+The output contains `Figure 1` and `Table 1` captions. References are native clickable Word `REF` fields; caption numbers are native `SEQ` fields wrapped in stable bookmarks. Figure and table sequences are independent and continue across every entry in `options.sections`, including forward references. Word is asked to refresh fields when the document opens, and deterministic cached values keep the generated DOCX readable before a refresh.
+
+Syntax and edge cases:
+
+- A figure must be a paragraph containing exactly one image. Its existing Markdown alt text remains the image's Word accessibility text; the separate caption paragraph supplies the visible caption and supports normal inline formatting.
+- A caption ID is case-sensitive, must use the matching `fig:` or `tbl:` prefix, cannot contain whitespace or braces, and is limited to 128 characters. Other punctuation is accepted and converted to a deterministic Word-safe bookmark.
+- The caption must be the next Markdown block. Without the blank line, Markdown treats the lines as one paragraph/table; without a valid adjacent caption, existing images and tables render unchanged.
+- By default, malformed captions, later duplicate IDs, and unresolved references remain visible as literal text. Set `captions.failureMode: "throw"` to reject them instead. The first duplicate definition wins in preserve mode.
+- Put `[@fig:id]` in inline code when it should remain literal. Caption/reference syntax is rejected with a clear validation error by the reference-DOCX patch APIs because patch order and existing bookmark collisions cannot be resolved safely yet.
+
+Labels, placement, and presentation can be adjusted without changing Markdown:
+
+```typescript
+await convertMarkdownToDocx(markdown, {
+  captions: {
+    figureLabel: "Illustration",
+    tableLabel: "Dataset",
+    figurePlacement: "below",
+    tablePlacement: "above",
+    alignment: "CENTER",
+    italic: true,
+    size: 20,
+    failureMode: "throw",
+  },
+});
+```
+
 ### Reference DOCX placeholder patching
 
 Use `patchMarkdownInDocxToBuffer` when you already have a Word template and want Markdown inserted at named placeholders. This workflow preserves the original DOCX package around the patched location, including existing styles, headers, footers, margins, cover pages, and static content.
@@ -296,7 +343,7 @@ Current limitations:
 - This is not a "reference styles" mode for generating a brand-new DOCX from another DOCX.
 - This does not append to the end of a document unless the template contains a placeholder at that location.
 - Markdown table width is not inferred from the reference DOCX. Set `tableWidthTwips` to match the placeholder section's content width when the template differs from the default A4 portrait width.
-- Ordered lists, generated `[TOC]`, and Word comments are rejected in patch markdown because they require package-level merges that are not supported yet.
+- Ordered lists, generated `[TOC]`, Word comments, and caption/cross-reference syntax are rejected in patch markdown because they require package-level ordering or merges that are not supported safely yet.
 - Browser use may work when you provide DOCX bytes, but this workflow is designed and tested for Node.
 
 ### Syntax-highlighted code blocks
@@ -582,6 +629,9 @@ await convertMarkdownToDocx(markdown, {
 | Callouts          | `> [!NOTE]`                    | GitHub-style callout blocks                          |
 | Links             | `[text](url)`                  |                                                      |
 | Images            | `![alt](url)`                  | HTTP(S) and `data:` URLs; supports `#w=...&h=...` sizing |
+| Figure captions   | `: Caption {#fig:id}`          | Place after a standalone image; automatic numbering      |
+| Table captions    | `: Caption {#tbl:id}`          | Place after a GFM table; automatic numbering             |
+| Cross-references  | `[@fig:id]`, `[@tbl:id]`       | Native clickable Word references; forward refs supported |
 | Footnotes         | `Text[^1]` + `[^1]: Note text` | Native Word footnotes                                |
 | Horizontal rule   | `---`                          | Skipped during conversion                            |
 | Table of Contents | `[TOC]`                        | Clickable, auto-populated                            |
@@ -651,11 +701,25 @@ interface Options {
   codeHighlighting?: CodeHighlightOptions;
   mermaidRendering?: MermaidRenderingOptions;
   chartRendering?: ChartRenderingOptions;
+  captions?: CaptionOptions;
   textReplacements?: TextReplacement[];
   textReplacementMode?: "trusted" | "untrusted";
   imageHandling?: ImageHandlingOptions;
 }
 ```
+
+#### `CaptionOptions`
+
+| Field             | Type                       | Default      | Description                                      |
+| ----------------- | -------------------------- | ------------ | ------------------------------------------------ |
+| `figureLabel`     | `string`                   | `"Figure"`   | Label rendered before figure numbers.            |
+| `tableLabel`      | `string`                   | `"Table"`    | Label rendered before table numbers.             |
+| `figurePlacement` | `"above" \| "below"`      | `"below"`    | Figure caption position.                         |
+| `tablePlacement`  | `"above" \| "below"`      | `"below"`    | Table caption position.                          |
+| `alignment`       | `AlignmentOption`          | `"CENTER"`   | Caption paragraph alignment.                     |
+| `italic`          | `boolean`                  | `false`      | Italicize caption labels and text.               |
+| `size`            | `number`                   | paragraph size | Caption size in half-points.                    |
+| `failureMode`     | `"preserve" \| "throw"`   | `"preserve"` | Preserve invalid syntax literally or fail early. |
 
 ### `PatchMarkdownOptions`
 

--- a/skills/md-to-docx/SKILL.md
+++ b/skills/md-to-docx/SKILL.md
@@ -95,6 +95,26 @@ Merge precedence:
 
 Use `pageNumbering.display` for common footer numbering modes: `none`, `current`, `currentAndTotal`, or `currentAndSectionTotal`.
 
+## Figure and Table References
+
+Place a Pandoc-style caption paragraph after a standalone image or table, with a blank line between the block and caption. Use `[@fig:id]` or `[@tbl:id]` in prose:
+
+```markdown
+See [@fig:flow] and [@tbl:metrics].
+
+![Accessible flow diagram](flow.png)
+
+: Request *flow* {#fig:flow}
+
+| Metric | Value |
+| --- | --- |
+| p95 | 120 ms |
+
+: Performance metrics {#tbl:metrics}
+```
+
+Figure and table numbering continues across sections. Use `options.captions` for labels, placement, alignment, italics, size, and `failureMode`. Reference-DOCX patch mode rejects this syntax with a validation error.
+
 ## Text Replacements
 
 Use `textReplacements` to rewrite text before conversion:
@@ -119,6 +139,7 @@ Support includes:
 - Tables (with inline formatting: bold, italic, code, links, strikethrough in cells)
 - Code blocks and inline code (with configurable `codeBlockAlignment`)
 - Links and images
+- Automatically numbered figure/table captions and clickable cross-references
 - Text replacements before rendering via `textReplacements`
 - `COMMENT: ...`
 - `[TOC]` on its own line

--- a/src/crossReferences.ts
+++ b/src/crossReferences.ts
@@ -1,0 +1,299 @@
+import type { Paragraph, PhrasingContent, Root, RootContent } from "mdast";
+import { MarkdownConversionError } from "./errors.js";
+import type { CaptionOptions } from "./types.js";
+import { crossReferenceBookmarkId } from "./utils/bookmarkUtils.js";
+
+export type CaptionKind = "figure" | "table";
+
+export interface CrossReferenceDefinition {
+  id: string;
+  kind: CaptionKind;
+  number: number;
+  bookmarkId: string;
+}
+
+export interface ResolvedCaption extends CrossReferenceDefinition {
+  children: PhrasingContent[];
+}
+
+export interface CrossReferenceRegistry {
+  definitions: Map<string, CrossReferenceDefinition>;
+  captionsByRoot: WeakMap<Root, Map<number, ResolvedCaption>>;
+  failureMode: NonNullable<CaptionOptions["failureMode"]>;
+  boundDefinitionIds: Set<string>;
+}
+
+interface CaptionCandidate {
+  id?: string;
+  children?: PhrasingContent[];
+  error?: string;
+}
+
+function isStandaloneImage(node: RootContent): boolean {
+  return (
+    node.type === "paragraph" &&
+    node.children.length === 1 &&
+    node.children[0].type === "image"
+  );
+}
+
+function captionKindForNode(node: RootContent): CaptionKind | undefined {
+  if (isStandaloneImage(node)) {
+    return "figure";
+  }
+  return node.type === "table" ? "table" : undefined;
+}
+
+function textFromPhrasingContent(node: PhrasingContent): string {
+  if ("value" in node && typeof node.value === "string") {
+    return node.value;
+  }
+  if ("children" in node && Array.isArray(node.children)) {
+    return node.children
+      .map((child) => textFromPhrasingContent(child as PhrasingContent))
+      .join("");
+  }
+  return "";
+}
+
+function parseCaptionParagraph(
+  paragraph: Paragraph,
+  kind: CaptionKind,
+): CaptionCandidate | null {
+  const first = paragraph.children[0];
+  const last = paragraph.children[paragraph.children.length - 1];
+  if (
+    !first ||
+    !last ||
+    first.type !== "text" ||
+    last.type !== "text" ||
+    !/^:\s+/.test(first.value)
+  ) {
+    return null;
+  }
+
+  const identifierMatch = last.value.match(/\s+\{#([^\s{}]+)\}\s*$/);
+  const plainText = paragraph.children.map(textFromPhrasingContent).join("");
+  if (!identifierMatch) {
+    return /\{#/.test(plainText)
+      ? { error: "Malformed caption identifier" }
+      : null;
+  }
+
+  const id = identifierMatch[1];
+  const expectedPrefix = kind === "figure" ? "fig:" : "tbl:";
+  if (!id.startsWith(expectedPrefix) || id.length === expectedPrefix.length) {
+    return {
+      id,
+      error: `${kind === "figure" ? "Figure" : "Table"} captions require a ${expectedPrefix} identifier`,
+    };
+  }
+  if (id.length > 128) {
+    return { id, error: "Caption identifiers must be at most 128 characters" };
+  }
+
+  const children = paragraph.children.map((child) => ({ ...child }));
+  const firstText = children[0];
+  const lastText = children[children.length - 1];
+  if (firstText.type !== "text" || lastText.type !== "text") {
+    return { id, error: "Malformed caption text" };
+  }
+
+  firstText.value = firstText.value.replace(/^:\s+/, "");
+  lastText.value = lastText.value.replace(/\s+\{#[^\s{}]+\}\s*$/, "");
+  const captionText = children.map(textFromPhrasingContent).join("").trim();
+  if (captionText.length === 0) {
+    return { id, error: "Captions must contain text" };
+  }
+
+  return { id, children };
+}
+
+function captionCandidateAt(
+  root: Root,
+  blockIndex: number,
+): { kind: CaptionKind; candidate: CaptionCandidate } | null {
+  const block = root.children[blockIndex];
+  const kind = captionKindForNode(block);
+  const caption = root.children[blockIndex + 1];
+  if (!kind || caption?.type !== "paragraph") {
+    return null;
+  }
+
+  const candidate = parseCaptionParagraph(caption, kind);
+  return candidate ? { kind, candidate } : null;
+}
+
+function definitionError(
+  registry: CrossReferenceRegistry,
+  message: string,
+  context: Record<string, unknown>,
+): void {
+  if (registry.failureMode === "throw") {
+    throw new MarkdownConversionError(message, context);
+  }
+}
+
+/**
+ * Discovers caption definitions in document order so numbering and forward
+ * references remain stable across Word sections.
+ */
+export function buildCrossReferenceRegistry(
+  roots: Root[],
+  options: CaptionOptions | undefined,
+): CrossReferenceRegistry {
+  const registry: CrossReferenceRegistry = {
+    definitions: new Map(),
+    captionsByRoot: new WeakMap(),
+    failureMode: options?.failureMode ?? "preserve",
+    boundDefinitionIds: new Set(),
+  };
+  const counters: Record<CaptionKind, number> = { figure: 0, table: 0 };
+
+  for (const root of roots) {
+    const captions = new Map<number, ResolvedCaption>();
+    registry.captionsByRoot.set(root, captions);
+
+    for (let index = 0; index < root.children.length - 1; index++) {
+      const parsed = captionCandidateAt(root, index);
+      if (!parsed) {
+        continue;
+      }
+
+      const { kind, candidate } = parsed;
+      if (candidate.error || !candidate.id || !candidate.children) {
+        definitionError(
+          registry,
+          candidate.error || "Malformed caption",
+          { kind, identifier: candidate.id },
+        );
+        continue;
+      }
+
+      const existing = registry.definitions.get(candidate.id);
+      if (existing) {
+        definitionError(registry, `Duplicate caption identifier: ${candidate.id}`, {
+          identifier: candidate.id,
+          firstKind: existing.kind,
+          duplicateKind: kind,
+        });
+        continue;
+      }
+
+      counters[kind]++;
+      const definition: CrossReferenceDefinition = {
+        id: candidate.id,
+        kind,
+        number: counters[kind],
+        bookmarkId: crossReferenceBookmarkId(candidate.id),
+      };
+      registry.definitions.set(definition.id, definition);
+      captions.set(index, { ...definition, children: candidate.children });
+    }
+  }
+
+  return registry;
+}
+
+export function captionAt(
+  registry: CrossReferenceRegistry | undefined,
+  root: Root,
+  blockIndex: number,
+): ResolvedCaption | undefined {
+  return registry?.captionsByRoot.get(root)?.get(blockIndex);
+}
+
+/**
+ * Binds the pre-scanned definitions to a freshly parsed AST. The first valid
+ * occurrence wins, matching duplicate-ID behavior from the discovery pass.
+ */
+export function bindCrossReferenceCaptions(
+  registry: CrossReferenceRegistry | undefined,
+  root: Root,
+): void {
+  if (!registry) {
+    return;
+  }
+
+  const existingCaptions = registry.captionsByRoot.get(root);
+  if (existingCaptions && existingCaptions.size > 0) {
+    for (const caption of existingCaptions.values()) {
+      registry.boundDefinitionIds.add(caption.id);
+    }
+    return;
+  }
+
+  const captions = new Map<number, ResolvedCaption>();
+  registry.captionsByRoot.set(root, captions);
+  for (let index = 0; index < root.children.length - 1; index++) {
+    const parsed = captionCandidateAt(root, index);
+    const id = parsed?.candidate.id;
+    if (
+      !parsed ||
+      parsed.candidate.error ||
+      !id ||
+      !parsed.candidate.children ||
+      registry.boundDefinitionIds.has(id)
+    ) {
+      continue;
+    }
+
+    const definition = registry.definitions.get(id);
+    if (!definition || definition.kind !== parsed.kind) {
+      continue;
+    }
+    captions.set(index, {
+      ...definition,
+      children: parsed.candidate.children,
+    });
+    registry.boundDefinitionIds.add(id);
+  }
+}
+
+export function resolveCrossReference(
+  registry: CrossReferenceRegistry | undefined,
+  id: string,
+): CrossReferenceDefinition | undefined {
+  return registry?.definitions.get(id);
+}
+
+export function throwOnUnresolvedCrossReference(
+  registry: CrossReferenceRegistry | undefined,
+  id: string,
+): void {
+  if (registry?.failureMode === "throw") {
+    throw new MarkdownConversionError(`Unresolved cross-reference: ${id}`, {
+      identifier: id,
+    });
+  }
+}
+
+/** Returns true when patch markdown uses syntax that cannot be safely patched. */
+export function containsCaptionOrCrossReferenceSyntax(root: Root): boolean {
+  for (let index = 0; index < root.children.length; index++) {
+    if (captionCandidateAt(root, index)) {
+      return true;
+    }
+  }
+
+  const stack: unknown[] = [...root.children];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || typeof node !== "object") {
+      continue;
+    }
+    const value = (node as { type?: string; value?: unknown }).value;
+    if (
+      (node as { type?: string }).type === "text" &&
+      typeof value === "string" &&
+      /\[@(?:fig|tbl):[^\]\s]+\]/.test(value)
+    ) {
+      return true;
+    }
+    const children = (node as { children?: unknown[] }).children;
+    if (Array.isArray(children)) {
+      stack.push(...children);
+    }
+  }
+  return false;
+}

--- a/src/docxModel.ts
+++ b/src/docxModel.ts
@@ -25,10 +25,27 @@ export interface DocxFootnoteReferenceNode {
   id: number;
 }
 
+export interface DocxCrossReferenceNode {
+  type: "crossReference";
+  id: string;
+  kind: "figure" | "table";
+  number: number;
+  bookmarkId: string;
+}
+
 export type DocxInlineNode =
   | DocxTextNode
   | DocxMathInlineNode
-  | DocxFootnoteReferenceNode;
+  | DocxFootnoteReferenceNode
+  | DocxCrossReferenceNode;
+
+export interface DocxCaption {
+  id: string;
+  kind: "figure" | "table";
+  number: number;
+  bookmarkId: string;
+  children: DocxInlineNode[];
+}
 
 export interface DocxParagraphNode {
   type: "paragraph";
@@ -93,6 +110,7 @@ export interface DocxImageNode {
   type: "image";
   alt: string;
   url: string;
+  caption?: DocxCaption;
 }
 
 export interface DocxTableNode {
@@ -100,6 +118,7 @@ export interface DocxTableNode {
   headers: DocxInlineNode[][];
   rows: DocxInlineNode[][][];
   align?: (string | null)[];
+  caption?: DocxCaption;
 }
 
 export interface DocxCommentNode {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   Style,
 } from "./types.js";
 import type { DocxBlockNode, DocxDocumentModel } from "./docxModel.js";
+import type { Root } from "mdast";
 import { parseMarkdownToAst, applyTextReplacements } from "./markdownAst.js";
 import { mdastToDocxModel } from "./mdastToDocxModel.js";
 import { modelToDocx } from "./modelToDocx.js";
@@ -45,6 +46,11 @@ import {
   throwIfAborted,
   yieldToAbortSignal,
 } from "./processingLimits.js";
+import {
+  buildCrossReferenceRegistry,
+  containsCaptionOrCrossReferenceSyntax,
+} from "./crossReferences.js";
+import type { CrossReferenceRegistry } from "./crossReferences.js";
 
 const defaultStyle: Style = {
   titleSize: 32,
@@ -72,6 +78,9 @@ export { MarkdownConversionError };
 export {
   CalloutStyle,
   CalloutType,
+  CaptionFailureMode,
+  CaptionOptions,
+  CaptionPlacement,
   ChartBlockDefinition,
   ChartBlockType,
   ChartDataset,
@@ -216,6 +225,10 @@ export async function parseToDocxOptions(
     const style: Style = { ...defaultStyle, ...normalizedStyle };
 
     const resolvedSections = resolveSections(markdown, options, style);
+    const crossReferences = await prepareCrossReferenceRegistry(
+      resolvedSections.map((section) => section.markdown),
+      options,
+    );
     const renderedSections: {
       children: (Paragraph | Table)[];
       style: Style;
@@ -247,6 +260,7 @@ export async function parseToDocxOptions(
           tocPlaceholders,
           tableWidthTwips: getSectionContentWidthTwips(section.config),
           footnoteIdOffset: maxFootnoteId,
+          crossReferences,
         }
       );
       elementCount = rendered.elementCount;
@@ -324,6 +338,9 @@ export async function parseToDocxOptions(
       styles: {
         paragraphStyles: buildParagraphStyles(style),
       },
+      ...(crossReferences && crossReferences.definitions.size > 0
+        ? { features: { updateFields: true } }
+        : {}),
     };
   } catch (error) {
     if (error instanceof MarkdownConversionError) {
@@ -415,6 +432,7 @@ async function patchMarkdownInDocxWithOutput(
           tableWidthTwips: options.tableWidthTwips,
           validateModel: (model) =>
             assertPatchCompatibleModel(model, placeholder),
+          validateAst: (ast) => assertPatchCompatibleAst(ast, placeholder),
         }
       );
       elementCount = rendered.elementCount;
@@ -540,6 +558,8 @@ async function renderMarkdownContent(
     tableWidthTwips?: number;
     footnoteIdOffset?: number;
     validateModel?: (model: DocxDocumentModel) => void;
+    validateAst?: (ast: Root) => void;
+    crossReferences?: CrossReferenceRegistry;
   } = {}
 ): Promise<{ content: RenderedMarkdownContent; elementCount: number }> {
   const ast = await parseMarkdownToAst(
@@ -556,6 +576,8 @@ async function renderMarkdownContent(
     );
   }
 
+  renderOptions.validateAst?.(ast);
+
   throwIfAborted(options.signal);
   const elementCount = enforceElementLimit(
     ast,
@@ -564,7 +586,12 @@ async function renderMarkdownContent(
     options.signal
   );
 
-  const model = mdastToDocxModel(ast, style, options);
+  const model = mdastToDocxModel(
+    ast,
+    style,
+    options,
+    renderOptions.crossReferences,
+  );
   renderOptions.validateModel?.(model);
   throwIfAborted(options.signal);
 
@@ -579,6 +606,49 @@ async function renderMarkdownContent(
   });
 
   return { content, elementCount };
+}
+
+async function prepareCrossReferenceRegistry(
+  markdownSections: string[],
+  options: Options,
+): Promise<CrossReferenceRegistry | undefined> {
+  const mayContainSyntax =
+    options.textReplacements !== undefined ||
+    markdownSections.some((section) =>
+      /(?:\{#(?:fig|tbl):|\[@(?:fig|tbl):)/.test(section),
+    );
+  if (!mayContainSyntax) {
+    return undefined;
+  }
+
+  const roots: Root[] = [];
+  for (const markdown of markdownSections) {
+    throwIfAborted(options.signal);
+    const ast = await parseMarkdownToAst(
+      markdown,
+      options.mathRendering?.enabled !== false,
+    );
+    if (options.textReplacements && options.textReplacements.length > 0) {
+      applyTextReplacements(
+        ast,
+        options.textReplacements,
+        options.textReplacementMode,
+      );
+    }
+    roots.push(ast);
+    await yieldToAbortSignal(options.signal);
+  }
+
+  return buildCrossReferenceRegistry(roots, options.captions);
+}
+
+function assertPatchCompatibleAst(ast: Root, placeholder: string): void {
+  if (containsCaptionOrCrossReferenceSyntax(ast)) {
+    throw new MarkdownConversionError(
+      "Patch markdown does not support captions or cross-references yet",
+      { placeholder },
+    );
+  }
 }
 
 function assertPatchCompatibleModel(

--- a/src/mdastToDocxModel.ts
+++ b/src/mdastToDocxModel.ts
@@ -28,6 +28,13 @@ import type {
   DocxFootnoteDefinitionNode,
 } from "./docxModel.js";
 import { Style, Options } from "./types.js";
+import {
+  captionAt,
+  bindCrossReferenceCaptions,
+  resolveCrossReference,
+  throwOnUnresolvedCrossReference,
+} from "./crossReferences.js";
+import type { CrossReferenceRegistry } from "./crossReferences.js";
 
 interface ProcessOptions {
   allowFootnoteReferences?: boolean;
@@ -99,7 +106,9 @@ export function mdastToDocxModel(
   root: Root,
   _style: Style,
   options: Options,
+  crossReferences?: CrossReferenceRegistry,
 ): DocxDocumentModel {
+  bindCrossReferenceCaptions(crossReferences, root);
   const children: DocxBlockNode[] = [];
   const footnoteDefinitions = new Map<string, FootnoteDefinition>();
   const referencedFootnoteIds = new Map<string, number>();
@@ -460,10 +469,38 @@ export function mdastToDocxModel(
       }
     }
 
+    function pushTextAndCrossReferences(value: string): void {
+      const referencePattern = /\[@((?:fig|tbl):[^\]\s]+)\]/g;
+      let cursor = 0;
+      for (const match of value.matchAll(referencePattern)) {
+        const matchIndex = match.index ?? 0;
+        if (matchIndex > cursor) {
+          pushTextWithUnderline(value.slice(cursor, matchIndex));
+        }
+
+        const identifier = match[1];
+        const definition = resolveCrossReference(crossReferences, identifier);
+        if (definition) {
+          result.push({
+            type: "crossReference",
+            ...definition,
+          });
+        } else {
+          throwOnUnresolvedCrossReference(crossReferences, identifier);
+          pushTextWithUnderline(match[0]);
+        }
+        cursor = matchIndex + match[0].length;
+      }
+
+      if (cursor < value.length) {
+        pushTextWithUnderline(value.slice(cursor));
+      }
+    }
+
     for (const node of nodes) {
       switch (node.type) {
         case "text":
-          pushTextWithUnderline((node as Text).value);
+          pushTextAndCrossReferences((node as Text).value);
           break;
         case "emphasis": {
           const emphasisChildren = processInlineNodes(
@@ -623,7 +660,9 @@ export function mdastToDocxModel(
   }
 
   // Process root children
-  for (const child of root.children) {
+  for (let childIndex = 0; childIndex < root.children.length; childIndex++) {
+    const child = root.children[childIndex];
+    const resolvedCaption = captionAt(crossReferences, root, childIndex);
     // Handle special cases for TOC and page breaks
     if (child.type === "paragraph") {
       const para = child as Paragraph;
@@ -660,6 +699,20 @@ export function mdastToDocxModel(
 
     const processed = processNode(child);
     if (processed) {
+      if (
+        resolvedCaption &&
+        !Array.isArray(processed) &&
+        (processed.type === "image" || processed.type === "table")
+      ) {
+        processed.caption = {
+          id: resolvedCaption.id,
+          kind: resolvedCaption.kind,
+          number: resolvedCaption.number,
+          bookmarkId: resolvedCaption.bookmarkId,
+          children: processInlineNodes(resolvedCaption.children),
+        };
+        childIndex++;
+      }
       if (Array.isArray(processed)) {
         children.push(...processed);
       } else {

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -10,6 +10,8 @@ import {
   AlignmentType,
   TableLayoutType,
   WidthType,
+  Bookmark,
+  SimpleField,
 } from "docx";
 import type { IParagraphOptions, ParagraphChild } from "docx";
 import type {
@@ -20,6 +22,7 @@ import type {
   DocxListItemNode,
   DocxInlineNode,
   DocxTextNode,
+  DocxCaption,
 } from "./docxModel.js";
 import { Style, Options } from "./types.js";
 import { processHeading } from "./renderers/headingRenderer.js";
@@ -189,7 +192,14 @@ export async function modelToDocx(
   ): ParagraphChild[] {
     const out: ParagraphChild[] = [];
     for (const node of nodes) {
-      if (node.type === "footnoteReference") {
+      if (node.type === "crossReference") {
+        out.push(
+          new SimpleField(
+            ` REF ${node.bookmarkId} \\h `,
+            `${captionLabel(node.kind)} ${node.number}`,
+          ),
+        );
+      } else if (node.type === "footnoteReference") {
         out.push(new FootnoteReferenceRun(node.id + footnoteIdOffset));
       } else if (node.type === "mathInline") {
         out.push(renderMathNode(node.value, false));
@@ -394,9 +404,79 @@ export async function modelToDocx(
         if (node.type === "text") {
           return node.value;
         }
+        if (node.type === "crossReference") {
+          return `${captionLabel(node.kind)} ${node.number}`;
+        }
         return "";
       })
       .join("");
+  }
+
+  function captionLabel(kind: DocxCaption["kind"]): string {
+    return kind === "figure"
+      ? options.captions?.figureLabel ?? "Figure"
+      : options.captions?.tableLabel ?? "Table";
+  }
+
+  function captionParagraph(caption: DocxCaption): Paragraph {
+    const label = captionLabel(caption.kind);
+    const sequenceName =
+      caption.kind === "figure" ? "MdToDocxFigure" : "MdToDocxTable";
+    const size = options.captions?.size ?? style.paragraphSize ?? 24;
+    const forceItalic = options.captions?.italic ?? false;
+    const alignment = options.captions?.alignment
+      ? AlignmentType[options.captions.alignment]
+      : AlignmentType.CENTER;
+    const bookmark = new Bookmark({
+      id: caption.bookmarkId,
+      children: [
+        textRunFromNode(
+          { type: "text", value: `${label} ` },
+          { forceItalic, size },
+        ),
+        new SimpleField(
+          ` SEQ ${sequenceName} \\* ARABIC `,
+          String(caption.number),
+        ),
+      ],
+    });
+
+    return new Paragraph({
+      style: "Caption",
+      children: [
+        bookmark,
+        textRunFromNode(
+          { type: "text", value: ": " },
+          { forceItalic, size },
+        ),
+        ...renderInlineNodes(caption.children, { forceItalic, size }),
+      ],
+      alignment,
+      spacing: {
+        before: style.paragraphSpacing / 2,
+        after: style.paragraphSpacing,
+        line: style.lineSpacing * 240,
+      },
+      bidirectional: style.direction === "RTL",
+    });
+  }
+
+  function withCaption(
+    node: Extract<DocxBlockNode, { type: "image" | "table" }>,
+    rendered: (Paragraph | Table)[],
+  ): (Paragraph | Table)[] {
+    if (!node.caption) {
+      return rendered;
+    }
+
+    const placement =
+      node.type === "image"
+        ? options.captions?.figurePlacement ?? "below"
+        : options.captions?.tablePlacement ?? "below";
+    const caption = captionParagraph(node.caption);
+    return placement === "above"
+      ? [caption, ...rendered]
+      : [...rendered, caption];
   }
 
   async function renderBlockNode(
@@ -471,7 +551,7 @@ export async function modelToDocx(
       }
 
       case "image": {
-        return renderImageNode(node, context);
+        return withCaption(node, await renderImageNode(node, context));
       }
 
       case "mermaidBlock": {
@@ -483,7 +563,7 @@ export async function modelToDocx(
       }
 
       case "table": {
-        return [tableFromNode(node)];
+        return withCaption(node, [tableFromNode(node)]);
       }
 
       case "comment": {

--- a/src/renderers/chartRenderer.ts
+++ b/src/renderers/chartRenderer.ts
@@ -172,6 +172,7 @@ export async function processChartBlock(
       },
       paragraphOptions,
       signal,
+      false,
     );
     return result;
   } catch (error) {

--- a/src/renderers/imageRenderer.ts
+++ b/src/renderers/imageRenderer.ts
@@ -181,6 +181,8 @@ export interface ProcessImageDataInput {
   maxImageBytes?: number;
   paragraphOptions?: Partial<IParagraphOptions>;
   signal?: AbortSignal;
+  /** Preserve Markdown image alt text in Word drawing properties. */
+  preserveAltText?: boolean;
 }
 
 /**
@@ -242,6 +244,15 @@ export function processImageData(
         children: [
           new ImageRun({
             data: imageData,
+            ...(input.preserveAltText
+              ? {
+                  altText: {
+                    name: input.altText || "Image",
+                    description: input.altText || undefined,
+                    title: input.altText || undefined,
+                  },
+                }
+              : {}),
             transformation: {
               width: outWidth,
               height: finalHeight,
@@ -269,6 +280,7 @@ export async function processImage(
   imageHandling?: ImageHandlingOptions,
   paragraphOptions: Partial<IParagraphOptions> = {},
   signal?: AbortSignal,
+  preserveAltText = true,
 ): Promise<ProcessImageResult> {
   try {
     throwIfAborted(signal);
@@ -370,6 +382,7 @@ export async function processImage(
         maxImageBytes: resolvedImageHandling.maxImageBytes,
         paragraphOptions,
         signal,
+        preserveAltText,
       },
       style,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,6 +295,36 @@ export interface Options {
    * default; when disabled, those fences render as ordinary code blocks.
    */
   chartRendering?: ChartRenderingOptions;
+  /**
+   * Labels, placement, styling, and validation behavior for figure/table
+   * captions and cross-references.
+   */
+  captions?: CaptionOptions;
+}
+
+export type CaptionPlacement = "above" | "below";
+export type CaptionFailureMode = "preserve" | "throw";
+
+export interface CaptionOptions {
+  /** Human-readable label before figure numbers. Defaults to "Figure". */
+  figureLabel?: string;
+  /** Human-readable label before table numbers. Defaults to "Table". */
+  tableLabel?: string;
+  /** Figure caption position relative to the image. Defaults to "below". */
+  figurePlacement?: CaptionPlacement;
+  /** Table caption position relative to the table. Defaults to "below". */
+  tablePlacement?: CaptionPlacement;
+  /** Caption paragraph alignment. Defaults to CENTER. */
+  alignment?: AlignmentOption;
+  /** Whether caption text is italic. Defaults to false. */
+  italic?: boolean;
+  /** Caption font size in half-points. Defaults to the paragraph size. */
+  size?: number;
+  /**
+   * Preserve malformed/duplicate syntax and unresolved references as literal
+   * text, or throw a MarkdownConversionError. Defaults to "preserve".
+   */
+  failureMode?: CaptionFailureMode;
 }
 
 export interface MathRenderingOptions {

--- a/src/utils/bookmarkUtils.ts
+++ b/src/utils/bookmarkUtils.ts
@@ -10,3 +10,21 @@ export function sanitizeForBookmarkId(text: string): string {
   }
   return sanitized.substring(0, 40);
 }
+
+function stableBookmarkHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(-7);
+}
+
+/**
+ * Creates a deterministic Word-safe bookmark for a user supplied caption ID.
+ * The hash prevents distinct unsafe IDs from collapsing to the same bookmark.
+ */
+export function crossReferenceBookmarkId(identifier: string): string {
+  const safeIdentifier = sanitizeForBookmarkId(identifier).slice(0, 24);
+  return `mdxref_${safeIdentifier}_${stableBookmarkHash(identifier)}`.slice(0, 40);
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,6 @@
 import {
   AlignmentOption,
+  CaptionOptions,
   CalloutType,
   DocumentSection,
   HeaderFooterGroup,
@@ -243,6 +244,68 @@ function validateMathRenderingInput(
     throw new MarkdownConversionError(
       'Invalid mathRendering.unsupported: Must be "text" or "throw"',
       { unsupported: mathRendering.unsupported }
+    );
+  }
+}
+
+function validateCaptionOptionsInput(captions: CaptionOptions | undefined): void {
+  if (!captions) {
+    return;
+  }
+
+  for (const [name, value] of [
+    ["figureLabel", captions.figureLabel],
+    ["tableLabel", captions.tableLabel],
+  ] as const) {
+    if (
+      value !== undefined &&
+      (typeof value !== "string" || value.trim().length === 0)
+    ) {
+      throw new MarkdownConversionError(
+        `Invalid captions.${name}: Must be a non-empty string`,
+      );
+    }
+  }
+
+  for (const [name, value] of [
+    ["figurePlacement", captions.figurePlacement],
+    ["tablePlacement", captions.tablePlacement],
+  ] as const) {
+    if (value !== undefined && value !== "above" && value !== "below") {
+      throw new MarkdownConversionError(
+        `Invalid captions.${name}: Must be above or below`,
+      );
+    }
+  }
+
+  if (
+    captions.alignment !== undefined &&
+    !validAlignments.includes(captions.alignment)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid captions.alignment: Must be LEFT, CENTER, RIGHT, or JUSTIFIED",
+    );
+  }
+  if (captions.italic !== undefined && typeof captions.italic !== "boolean") {
+    throw new MarkdownConversionError(
+      "Invalid captions.italic: Must be a boolean",
+    );
+  }
+  if (
+    captions.size !== undefined &&
+    (!Number.isFinite(captions.size) || captions.size < 8 || captions.size > 144)
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid captions.size: Must be between 8 and 144 half-points",
+    );
+  }
+  if (
+    captions.failureMode !== undefined &&
+    captions.failureMode !== "preserve" &&
+    captions.failureMode !== "throw"
+  ) {
+    throw new MarkdownConversionError(
+      "Invalid captions.failureMode: Must be preserve or throw",
     );
   }
 }
@@ -630,6 +693,7 @@ export function validateInput(markdown: string, options: Options): void {
   validateStyleInput(normalizeStyleInput(options.style), "options.style");
   validateTocOptionsInput(options.toc);
   validateMathRenderingInput(options.mathRendering);
+  validateCaptionOptionsInput(options.captions);
   validateImageHandlingInput(options.imageHandling);
   validateChartRenderingInput(options.chartRendering);
   validateMermaidRenderingInput(options.mermaidRendering);

--- a/tests/captions-cross-references.test.ts
+++ b/tests/captions-cross-references.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  convertMarkdownToDocx,
+  MarkdownConversionError,
+} from "../src/index";
+import { getDocumentXml, getZip } from "./helpers";
+
+const ONE_PX_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAGgwJ/vk9yBgAAAABJRU5ErkJggg==";
+
+async function render(markdown: string, options = {}): Promise<string> {
+  return getDocumentXml(await convertMarkdownToDocx(markdown, options));
+}
+
+function fieldInstructions(xml: string, field: "SEQ" | "REF"): string[] {
+  return Array.from(
+    xml.matchAll(new RegExp(`<w:fldSimple w:instr=" ([^"]*${field}[^"]*)">`, "g")),
+    (match) => match[1],
+  );
+}
+
+describe("figure/table captions and cross-references", () => {
+  it("numbers figures and tables independently with native fields and bookmarks", async () => {
+    const markdown = `See [@fig:overview] and [@tbl:results].
+
+![Architecture overview](${ONE_PX_PNG})
+
+: System *overview* {#fig:overview}
+
+| Metric | Value |
+| --- | --- |
+| Score | 42 |
+
+: **Results** summary {#tbl:results}`;
+    const blob = await convertMarkdownToDocx(markdown);
+    const xml = await getDocumentXml(blob);
+    const settings = await (await getZip(blob))
+      .file("word/settings.xml")
+      ?.async("string");
+
+    expect(fieldInstructions(xml, "SEQ")).toEqual([
+      "SEQ MdToDocxFigure \\* ARABIC ",
+      "SEQ MdToDocxTable \\* ARABIC ",
+    ]);
+    expect(fieldInstructions(xml, "REF")).toHaveLength(2);
+    expect(xml).toMatch(/w:name="mdxref_figoverview_[a-z0-9]+"/);
+    expect(xml).toMatch(/w:name="mdxref_tblresults_[a-z0-9]+"/);
+    expect(xml).toContain("Figure 1");
+    expect(xml).toContain("Table 1");
+    expect(xml).toMatch(/<w:i\/>[\s\S]*?>overview<\/w:t>/);
+    expect(xml).toMatch(/<w:b\/>[\s\S]*?>Results<\/w:t>/);
+    expect(settings).toContain("<w:updateFields/>");
+  });
+
+  it("supports multiple clickable forward references", async () => {
+    const xml = await render(`First [@fig:later], then [@fig:later] again.
+
+![Forward reference](${ONE_PX_PNG})
+
+: Defined later {#fig:later}`);
+    const refs = fieldInstructions(xml, "REF");
+
+    expect(refs).toHaveLength(2);
+    expect(refs.every((instruction) => instruction.includes("\\h"))).toBe(true);
+    expect(xml.match(/Figure 1/g)).toHaveLength(2);
+  });
+
+  it("continues automatic numbering across document sections", async () => {
+    const xml = await getDocumentXml(
+      await convertMarkdownToDocx("", {
+        sections: [
+          {
+            markdown: `![First](${ONE_PX_PNG})
+
+: First section {#fig:first}`,
+          },
+          {
+            markdown: `Reference [@fig:first].
+
+![Second](${ONE_PX_PNG})
+
+: Second section {#fig:second}
+
+| A |
+| --- |
+| B |
+
+: Section table {#tbl:section}`,
+          },
+        ],
+      }),
+    );
+
+    expect(xml).toContain("Figure 1");
+    expect(xml).toMatch(
+      /SEQ MdToDocxFigure[^"]*">(?:(?!<\/w:fldSimple>)[\s\S])*?>2<\/w:t>/,
+    );
+    expect(xml).toMatch(
+      /SEQ MdToDocxTable[^"]*">(?:(?!<\/w:fldSimple>)[\s\S])*?>1<\/w:t>/,
+    );
+    expect(fieldInstructions(xml, "SEQ")).toHaveLength(3);
+  });
+
+  it("keeps the first duplicate ID and preserves later duplicate syntax by default", async () => {
+    const xml = await render(`![First](${ONE_PX_PNG})
+
+: First caption {#fig:duplicate}
+
+![Second](${ONE_PX_PNG})
+
+: Duplicate caption {#fig:duplicate}
+
+See [@fig:duplicate].`);
+
+    expect(fieldInstructions(xml, "SEQ")).toHaveLength(1);
+    expect(xml).toContain("Duplicate caption");
+    expect(xml).toContain("{#fig:duplicate}");
+    expect(xml).toContain("Figure 1");
+  });
+
+  it("can fail on duplicate, malformed, and unresolved identifiers", async () => {
+    const duplicate = `![One](${ONE_PX_PNG})
+
+: One {#fig:same}
+
+![Two](${ONE_PX_PNG})
+
+: Two {#fig:same}`;
+    await expect(
+      convertMarkdownToDocx(duplicate, {
+        captions: { failureMode: "throw" },
+      }),
+    ).rejects.toThrow("Duplicate caption identifier");
+
+    await expect(
+      convertMarkdownToDocx(`![Bad](${ONE_PX_PNG})
+
+: Bad ID {#tbl:not-a-figure}`, {
+        captions: { failureMode: "throw" },
+      }),
+    ).rejects.toThrow("Figure captions require a fig: identifier");
+
+    await expect(
+      convertMarkdownToDocx("Missing [@fig:unknown].", {
+        captions: { failureMode: "throw" },
+      }),
+    ).rejects.toThrow(MarkdownConversionError);
+    await expect(
+      convertMarkdownToDocx("Missing [@fig:unknown].", {
+        captions: { failureMode: "throw" },
+      }),
+    ).rejects.toThrow("Unresolved cross-reference");
+  });
+
+  it("preserves unresolved references as literal text by default", async () => {
+    const xml = await render("Missing [@tbl:nope] remains visible.");
+
+    expect(xml).toContain("[@tbl:nope]");
+    expect(fieldInstructions(xml, "REF")).toHaveLength(0);
+  });
+
+  it("sanitizes unsafe IDs into stable collision-resistant Word bookmarks", async () => {
+    const markdown = `See [@fig:a/b?c].
+
+![Unsafe ID](${ONE_PX_PNG})
+
+: Unsafe identifier {#fig:a/b?c}`;
+    const first = await render(markdown);
+    const second = await render(markdown);
+    const bookmark = first.match(/w:name="(mdxref_[^"]+)"/)?.[1];
+
+    expect(bookmark).toBeDefined();
+    expect(bookmark).toMatch(/^[A-Za-z_][A-Za-z0-9_]{0,39}$/);
+    expect(bookmark).not.toContain("/");
+    expect(bookmark).not.toContain("?");
+    expect(second).toContain(`w:name="${bookmark}"`);
+    expect(first).toContain(`REF ${bookmark} \\h`);
+  });
+
+  it("applies typed labels, placement, and caption styling", async () => {
+    const xml = await render(
+      `![Styled](${ONE_PX_PNG})
+
+: Styled caption {#fig:styled}`,
+      {
+        captions: {
+          figureLabel: "Illustration",
+          figurePlacement: "above",
+          alignment: "LEFT",
+          italic: true,
+          size: 20,
+        },
+      },
+    );
+    const captionIndex = xml.indexOf("Illustration");
+    const imageIndex = xml.indexOf("<w:drawing>");
+
+    expect(captionIndex).toBeGreaterThan(-1);
+    expect(captionIndex).toBeLessThan(imageIndex);
+    expect(xml.slice(captionIndex - 500, captionIndex)).toContain('w:val="left"');
+    expect(xml).toMatch(/<w:i\/>[\s\S]*?<w:sz w:val="20"\/>/);
+  });
+
+  it("does not reinterpret ordinary images, tables, links, or inline code", async () => {
+    const blob = await convertMarkdownToDocx(`![Accessible ordinary image](${ONE_PX_PNG})
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+[External link](https://example.com) and \`[@fig:literal]\`.`);
+    const xml = await getDocumentXml(blob);
+    const rels = await (await getZip(blob))
+      .file("word/_rels/document.xml.rels")
+      ?.async("string");
+
+    expect(xml).toContain("<w:tbl>");
+    expect(xml).toContain("<w:hyperlink");
+    expect(xml).toContain("[@fig:literal]");
+    expect(xml).toContain('descr="Accessible ordinary image"');
+    expect(fieldInstructions(xml, "SEQ")).toHaveLength(0);
+    expect(fieldInstructions(xml, "REF")).toHaveLength(0);
+    expect(rels).toContain("https://example.com");
+  });
+});

--- a/tests/reference-docx-patch.test.ts
+++ b/tests/reference-docx-patch.test.ts
@@ -147,4 +147,20 @@ Hello **team**.
       })
     ).rejects.toThrow("ordered lists");
   });
+
+  it("fails clearly when patch markdown uses captions or cross-references", async () => {
+    const template = fs.readFileSync(fixturePath);
+
+    await expect(
+      patchMarkdownInDocxToBuffer(template, {
+        body: `| A |
+| --- |
+| B |
+
+: Patched table {#tbl:patched}`,
+      }),
+    ).rejects.toThrow(
+      "Patch markdown does not support captions or cross-references yet",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds figure/table captions, automatic document-wide numbering, stable bookmarks, and clickable internal cross-references for the v3 release train.

## Markdown syntax

A caption is a separate paragraph immediately after a standalone image or GFM table, with a blank line before it:

```markdown
See [@fig:architecture] and [@tbl:results].

![Accessible architecture diagram](architecture.png)

: System *architecture* {#fig:architecture}

| Metric | Value |
| --- | ---: |
| Accuracy | 98% |

: **Evaluation** results {#tbl:results}
```

- Figure IDs use `fig:`; table IDs use `tbl:`.
- IDs are case-sensitive, contain no whitespace/braces, and are capped at 128 characters.
- Other punctuation is accepted and converted to deterministic Word-safe bookmark names.
- References use `[@fig:id]` or `[@tbl:id]`; forward references work.
- By default malformed captions, later duplicate IDs, and unresolved references remain literal. `captions.failureMode: "throw"` rejects them.
- The first duplicate definition wins in preserve mode. Inline code keeps reference syntax literal.

## Implementation

- Pre-scans section ASTs to assign independent figure/table numbers in full-document order.
- Emits cached native Word `SEQ` fields inside stable bookmarks for captions.
- Emits cached native Word `REF ... \\h` fields for clickable internal references.
- Enables Word field refresh while retaining readable cached values before refresh.
- Preserves caption inline formatting, Markdown image alt text, image security/limits, table formatting, TOC bookmarks, RTL paragraph behavior, abort checks, and existing chart/Mermaid behavior.
- Adds a small typed `captions` option for labels, placement, alignment, italics, size, and failure behavior.

## Compatibility and user impact

Existing images, tables, links, inline code, and documents without caption syntax render as before. Numbering continues across `options.sections`, so multi-section reports can reference any figure or table.

Reference-DOCX patch mode rejects caption/reference syntax with a clear validation error. It does not attempt unsafe numbering across placeholder/object order or risk collisions with bookmarks already present in a reference package.

No package version was changed; this PR targets `feature/v3`.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` — 183 tests passed
- `npm run test:consumer` — node16, nodenext, and bundler resolution passed
- XML-level coverage includes numbering, multiple/forward references, multi-section numbering, duplicates, malformed/unresolved references, sanitized IDs, inline caption formatting, typed styling/placement, patch validation, and ordinary image/table/link regressions.
- Generated DOCX passed ZIP integrity checks and opened/rendered through LibreOffice as a one-page PDF showing Figure 1/Table 1 captions and forward-reference text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core conversion (AST pre-scan, mdast model, DOCX field emission) and multi-section ordering; behavior is opt-in via syntax and defaults preserve legacy output, but caption/registry bugs could affect numbering and links across long documents.
> 
> **Overview**
> Adds **Pandoc-style figure and table captions** with `[@fig:id]` / `[@tbl:id]` cross-references for Markdown→DOCX conversion.
> 
> A new `crossReferences` pass pre-scans all section ASTs (after optional `textReplacements`) to assign independent figure/table numbers in document order, including forward references across `options.sections`. Captions attach to standalone images and GFM tables; prose references become native Word `REF` fields, caption numbers use `SEQ` inside stable bookmarks, and documents with captions enable `updateFields` on open with cached display text.
> 
> New exported **`CaptionOptions`** (`figureLabel`, `tableLabel`, placement, alignment, italic, size, `failureMode`) controls presentation and whether malformed/duplicate/unresolved syntax is preserved literally or throws. **Reference-DOCX patching** now fails validation when patch markdown contains caption or cross-reference syntax.
> 
> Docs, changelog, agent skill, validation, bookmark hashing for unsafe IDs, and XML-level tests cover numbering, multi-section continuity, duplicates, and patch rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fab02117dfa920174fbac43f11fc0325ac71e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->