### PR TITLE
feat: add reference DOCX style mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Features
+
+- Add a true reference-DOCX style generation workflow through `convertMarkdownWithReferenceDocx`, `convertMarkdownWithReferenceDocxToArrayBuffer`, and `convertMarkdownWithReferenceDocxToBuffer`.
+- Adopt named paragraph, character, and table styles with typed ID/name overrides while preserving theme/fonts, final-section page presentation, and headers/footers without copying static reference body content.
+- Merge reference numbering, relationships, and content types with collision-safe IDs and bounded untrusted-ZIP validation, cancellation, and actionable `ReferenceDocxErrorContext` codes.
+
 ## [2.18.0](https://github.com/MohtashamMurshid/md-to-docx/compare/v2.17.0...v2.18.0) (2026-06-19)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A TypeScript-first library and CLI that turns Markdown into production-ready Wor
   - [Text find-and-replace](#text-find-and-replace)
   - [Server-side processing limits](#server-side-processing-limits)
   - [RTL / bidirectional text](#rtl--bidirectional-text)
+  - [Reference DOCX style generation](#reference-docx-style-generation)
   - [Reference DOCX placeholder patching](#reference-docx-placeholder-patching)
 - [Supported Markdown](#supported-markdown)
 - [API reference](#api-reference)
@@ -52,6 +53,7 @@ A TypeScript-first library and CLI that turns Markdown into production-ready Wor
 - **TypeScript-native** — fully typed options surface, including `CodeHighlightTheme`, `Options`, and `DocumentSection`.
 - **Multi-section documents** — cover pages, per-section headers/footers, page numbering resets, mixed orientations, style overrides.
 - **Reference DOCX patching** — Node-friendly placeholder replacement for inserting generated Markdown into an existing `.docx` package.
+- **Reference DOCX style generation** — create a fresh Markdown-derived document while adopting named styles, theme/fonts, page geometry, and final-section headers/footers from a trusted or untrusted Word reference.
 - **Optional syntax highlighting** — opt-in, powered by `[lowlight](https://github.com/wooorm/lowlight)`; ships a GitHub-light theme and lets you override any token color.
 - **Native Word math** — Markdown `$...$` and `$$...$$` equations render as editable Word math for a documented TeX subset.
 - **Works everywhere** — Node.js (18+) and modern browsers; the package ships ESM with type declarations.
@@ -124,6 +126,8 @@ The `--options` JSON file accepts the same shape as the programmatic `Options` a
   "codeHighlighting": { "enabled": true }
 }
 ```
+
+Reference-DOCX style generation and placeholder patching require binary DOCX input, so they are programmatic APIs rather than CLI flags. The CLI continues to use ordinary `convertMarkdownToBuffer`; a JSON `reference` field is not loaded as a file path.
 
 For a multi-section document, use `template` + `sections` (the CLI ignores the positional markdown argument when `sections` is provided):
 
@@ -244,6 +248,77 @@ const blob = await convertMarkdownToDocx("", {
 
 **Precedence (last wins):** global `style` → `template.style` → per-section `style`. For `headers` / `footers`, each slot (`default`, `first`, `even`) can inherit, override, or be explicitly disabled with `null`.
 
+### Reference DOCX style generation
+
+Use `convertMarkdownWithReferenceDocxToBuffer` to generate a **brand-new** document whose content comes only from Markdown while its Word presentation comes from an existing `.docx`. This is the reference-styles workflow; it does not look for placeholders and does not copy cover pages, closing paragraphs, or any other static body content from the reference.
+
+```typescript
+import {
+  convertMarkdownWithReferenceDocxToBuffer,
+} from "@mohtasham/md-to-docx";
+import fs from "node:fs/promises";
+
+const reference = await fs.readFile("corporate-reference.docx");
+const markdown = `# Quarterly Update
+
+Revenue increased **18%**.
+
+1. Confirm the forecast
+2. Publish the board pack`;
+
+const output = await convertMarkdownWithReferenceDocxToBuffer(
+  markdown,
+  reference,
+  {
+    reference: {
+      styles: {
+        normal: { name: "Corporate Body" },
+        heading1: { id: "CorpHeading1" },
+        blockquote: { name: "Executive Quote" },
+        codeBlock: { name: "Code Block" },
+        table: { name: "Corporate Table" },
+      },
+      missingStyleBehavior: "throw",
+      duplicateStyleNameBehavior: "throw",
+      preservePageLayout: true,
+      preserveHeadersAndFooters: true,
+    },
+  },
+);
+
+await fs.writeFile("quarterly-update.docx", output);
+```
+
+Style selectors are exact and deterministic. `{ id: "..." }` matches `w:styleId`; `{ name: "..." }` matches the visible `w:name`. Supported roles are `normal`, `title`, `heading1` through `heading6`, `blockquote`, `codeBlock`, `caption`, `listParagraph`, `table`, `strong`, `emphasis`, `inlineCode`, and `hyperlink`. Omitted roles try conventional Word IDs/names and otherwise retain generated formatting; `null` disables reference adoption for that role. `missingStyleBehavior` applies to explicit selectors and defaults to `"fallback"`. Duplicate name selectors throw by default; use an ID to disambiguate or deliberately set `duplicateStyleNameBehavior: "first"`.
+
+The package merge preserves or derives:
+
+- Reference `styles.xml`, including paragraph, character, table styles, document defaults, and style links; converter-required styles missing from the reference are appended.
+- Theme and font-table parts reached through the reference document relationships, including bounded embedded-font parts.
+- Reference numbering definitions, remapped above generated abstract/instance IDs so Markdown bullets and ordered lists cannot collide with style-linked numbering.
+- Final-reference-section page size, orientation, margins, columns/grid, page-number settings, and header/footer references. The same reference presentation is applied to every newly generated section, and table width is derived from the adopted page geometry.
+- Header/footer XML plus internal image dependencies and external hyperlinks. External relationships are never fetched during conversion.
+
+Deliberate exclusions and limitations:
+
+- Reference body content, comments, footnotes, custom properties, document settings, macros, embedded objects, and unused media are not copied.
+- Only the final reference section is used as the presentation source. Multi-section reference-body sequencing is not replayed.
+- Header/footer internal relationships other than images (for example charts, OLE objects, or `altChunk`) throw `MarkdownConversionError` instead of silently creating a broken or active-content package.
+- Caption mapping applies when generated content contains a `Caption` paragraph style; image alt text is not promoted into a separate caption by this mode.
+- `Buffer` output is Node-only. Blob/ArrayBuffer helpers work in modern browsers with in-memory DOCX bytes, but Node is the primary tested environment for reference-package workflows.
+
+Reference DOCX files are treated as untrusted ZIP packages. Entry paths are checked, external relationships are not fetched, XML DTD/entity declarations are rejected, and processing honors `AbortSignal`. Defaults are 16 MiB compressed, 64 MiB total uncompressed, 16 MiB per entry, and 512 entries; override them with `reference.limits`. Malformed packages and limit failures throw `MarkdownConversionError` with a typed `ReferenceDocxErrorContext` such as `{ phase: "reference-docx", code: "PACKAGE_LIMIT_EXCEEDED", limit, actual }`.
+
+#### Migration and design notes
+
+Choose the workflow by ownership of the body:
+
+- Use ordinary `convertMarkdownToDocx*` when the converter owns both content and styling. Its output path is unchanged when reference mode is unused.
+- Use `convertMarkdownWithReferenceDocx*` when Markdown owns all new body content and an existing DOCX supplies reusable presentation.
+- Use `patchMarkdownInDocx*` when the existing DOCX body must remain and Markdown belongs only at named placeholders.
+
+Moving from placeholder patching to reference-style generation usually means deleting placeholders from the workflow, passing the full Markdown document once, and adding role selectors for organization-specific style names. Static cover or boilerplate content must be expressed as Markdown/new sections or retained via placeholder patching; it is intentionally not inherited by reference-style generation.
+
 ### Reference DOCX placeholder patching
 
 Use `patchMarkdownInDocxToBuffer` when you already have a Word template and want Markdown inserted at named placeholders. This workflow preserves the original DOCX package around the patched location, including existing styles, headers, footers, margins, cover pages, and static content.
@@ -293,7 +368,7 @@ Supported in this first mode:
 
 Current limitations:
 
-- This is not a "reference styles" mode for generating a brand-new DOCX from another DOCX.
+- This API patches an existing body; use `convertMarkdownWithReferenceDocx*` for a brand-new document that adopts reference styles.
 - This does not append to the end of a document unless the template contains a placeholder at that location.
 - Markdown table width is not inferred from the reference DOCX. Set `tableWidthTwips` to match the placeholder section's content width when the template differs from the default A4 portrait width.
 - Ordered lists, generated `[TOC]`, and Word comments are rejected in patch markdown because they require package-level merges that are not supported yet.
@@ -588,6 +663,8 @@ await convertMarkdownToDocx(markdown, {
 | Page break        | `\pagebreak`                   | Place on its own line                                |
 | Comments          | `<!-- COMMENT: text -->`       | Rendered as Word comments                            |
 
+Reference-style generation supports the same Markdown surface, including ordered/bullet lists, tables, images, links, footnotes, and generated TOCs. Package-level parts produced from Markdown remain owned by the converter; reference numbering and presentation parts are merged around them with collision-safe IDs.
+
 Markdown footnotes use the GFM/remark syntax:
 
 ```markdown
@@ -618,6 +695,18 @@ Converts Markdown text to DOCX bytes in any runtime with `ArrayBuffer` support.
 ### `convertMarkdownToBuffer(markdown, options?): Promise<Buffer>`
 
 Node-friendly helper for writing DOCX output to disk, object storage, or HTTP responses.
+
+### `convertMarkdownWithReferenceDocx(markdown, referenceDocx, options?): Promise<Blob>`
+
+Generates a fresh Markdown-derived DOCX and adopts named styles and selected presentation parts from reference DOCX bytes. The reference body is excluded.
+
+### `convertMarkdownWithReferenceDocxToArrayBuffer(markdown, referenceDocx, options?): Promise<ArrayBuffer>`
+
+ArrayBuffer-returning reference-style helper for runtimes with in-memory DOCX bytes.
+
+### `convertMarkdownWithReferenceDocxToBuffer(markdown, referenceDocx, options?): Promise<Buffer>`
+
+Node-friendly reference-style helper. `referenceDocx` accepts `Buffer`, `Uint8Array`, `ArrayBuffer`, or `Blob` bytes; string/path inputs are rejected rather than read implicitly.
 
 ### `patchMarkdownInDocx(referenceDocx, patches, options?): Promise<Blob>`
 
@@ -654,6 +743,39 @@ interface Options {
   textReplacements?: TextReplacement[];
   textReplacementMode?: "trusted" | "untrusted";
   imageHandling?: ImageHandlingOptions;
+}
+```
+
+### `ReferenceDocxGenerationOptions`
+
+```typescript
+type ReferenceDocxStyleSelector =
+  | { id: string; name?: never }
+  | { name: string; id?: never };
+
+type ReferenceDocxStyleRole =
+  | "normal" | "title"
+  | "heading1" | "heading2" | "heading3"
+  | "heading4" | "heading5" | "heading6"
+  | "blockquote" | "codeBlock" | "caption" | "listParagraph"
+  | "table" | "strong" | "emphasis" | "inlineCode" | "hyperlink";
+
+interface ReferenceDocxGenerationOptions extends Options {
+  reference?: {
+    styles?: Partial<
+      Record<ReferenceDocxStyleRole, ReferenceDocxStyleSelector | null>
+    >;
+    missingStyleBehavior?: "fallback" | "throw";
+    duplicateStyleNameBehavior?: "first" | "throw";
+    preservePageLayout?: boolean;
+    preserveHeadersAndFooters?: boolean;
+    limits?: {
+      maxCompressedBytes?: number;
+      maxUncompressedBytes?: number;
+      maxEntryUncompressedBytes?: number;
+      maxEntries?: number;
+    };
+  };
 }
 ```
 
@@ -818,7 +940,7 @@ Alignment & direction
 
 ### Errors
 
-All conversion failures throw `MarkdownConversionError` (exported from the root). The error exposes a typed `context` field (e.g. `{ orientation, sectionIndex }`) to make debugging easier.
+All conversion failures throw `MarkdownConversionError` (exported from the root). The error exposes a typed `context` field (e.g. `{ orientation, sectionIndex }`) to make debugging easier. Reference-package failures use exported `ReferenceDocxErrorContext` and stable codes including `INVALID_ZIP`, `INVALID_PACKAGE`, `UNSAFE_ENTRY_PATH`, `PACKAGE_LIMIT_EXCEEDED`, `MISSING_STYLE`, `DUPLICATE_STYLE_NAME`, `STYLE_TYPE_MISMATCH`, `UNSUPPORTED_RELATIONSHIP`, and `ABORTED`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ const output = await convertMarkdownWithReferenceDocxToBuffer(
 await fs.writeFile("quarterly-update.docx", output);
 ```
 
-Style selectors are exact and deterministic. `{ id: "..." }` matches `w:styleId`; `{ name: "..." }` matches the visible `w:name`. Supported roles are `normal`, `title`, `heading1` through `heading6`, `blockquote`, `codeBlock`, `caption`, `listParagraph`, `table`, `strong`, `emphasis`, `inlineCode`, and `hyperlink`. Omitted roles try conventional Word IDs/names and otherwise retain generated formatting; `null` disables reference adoption for that role. `missingStyleBehavior` applies to explicit selectors and defaults to `"fallback"`. Duplicate name selectors throw by default; use an ID to disambiguate or deliberately set `duplicateStyleNameBehavior: "first"`.
+Style selectors are exact and deterministic. `{ id: "..." }` matches `w:styleId`; `{ name: "..." }` matches the visible `w:name`. Supported roles are `normal`, `title`, `heading1` through `heading6`, `blockquote`, `codeBlock`, `caption`, `listParagraph`, `table`, `strong`, `emphasis`, `inlineCode`, and `hyperlink`. Omitted roles try conventional Word IDs/names and otherwise retain generated formatting; when an automatic name match is duplicated, the first definition in document order wins. `null` disables reference adoption for that role. `missingStyleBehavior` applies to explicit selectors and defaults to `"fallback"`. Duplicate explicit name selectors throw by default; use an ID to disambiguate or deliberately set `duplicateStyleNameBehavior: "first"`.
 
 The package merge preserves or derives:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "docx": "^9.5.0",
         "file-saver": "^2.0.5",
+        "jszip": "^3.10.1",
         "lowlight": "^3.3.0",
         "mdast-util-find-and-replace": "^3.0.2",
         "remark": "^15.0.1",
@@ -37,7 +38,6 @@
         "eslint": "^9.39.4",
         "globals": "^17.6.0",
         "jest": "^29.7.0",
-        "jszip": "^3.10.1",
         "semantic-release": "25.0.3",
         "ts-jest": "^29.1.2",
         "typescript": "^5.8.2"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint": "^9.39.4",
     "globals": "^17.6.0",
     "jest": "^29.7.0",
-    "jszip": "^3.10.1",
     "semantic-release": "25.0.3",
     "ts-jest": "^29.1.2",
     "typescript": "^5.8.2"
@@ -70,6 +69,7 @@
   "dependencies": {
     "docx": "^9.5.0",
     "file-saver": "^2.0.5",
+    "jszip": "^3.10.1",
     "lowlight": "^3.3.0",
     "mdast-util-find-and-replace": "^3.0.2",
     "remark": "^15.0.1",

--- a/skills/md-to-docx/SKILL.md
+++ b/skills/md-to-docx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: md-to-docx
-description: Convert Markdown files and strings into DOCX documents using @mohtasham/md-to-docx. Use when a user needs Markdown to Word conversion, CLI-based file conversion, options-driven styling/alignment/font family, TOC/page break handling, underline/strikethrough formatting, multi-section documents with per-section headers/footers, or programmatic conversion in Node/browser code.
+description: Convert Markdown files and strings into DOCX documents using @mohtasham/md-to-docx. Use when a user needs Markdown to Word conversion, CLI-based file conversion, reference-DOCX styles or placeholder patching, options-driven styling/alignment/font family, TOC/page break handling, underline/strikethrough formatting, multi-section documents with per-section headers/footers, or programmatic conversion in Node/browser code.
 ---
 
 # md-to-docx
@@ -35,6 +35,7 @@ CLI contract:
 - Options JSON can include the same shapes as the API: `style`, `template`, `sections`, and `textReplacements`
 - Help flags: `-h` or `--help`
 - On success, expect: `DOCX created at: <absolute-path>`
+- Reference DOCX modes require binary input and are programmatic APIs, not CLI flags.
 
 ## Programmatic Mode
 
@@ -58,6 +59,15 @@ downloadDocx(blob, "output.docx");
 
 Use `convertMarkdownToDocx(markdown, options?)` to produce a DOCX `Blob`.
 Use `downloadDocx(blob, filename?)` only in browser environments.
+
+## Reference DOCX Workflows
+
+Choose one explicitly:
+
+- `convertMarkdownWithReferenceDocxToBuffer(markdown, referenceBytes, options?)` creates a fresh Markdown-owned body and adopts reference named styles, theme/fonts, final-section page layout, and headers/footers.
+- `patchMarkdownInDocxToBuffer(referenceBytes, patches, options?)` preserves the existing body and replaces named placeholders such as `{{body}}`.
+
+Reference-style generation never copies static reference body text. Prefer exact `{ id: "..." }` selectors when style names are duplicated; use `{ name: "..." }` for visible Word names. Treat uploaded references as untrusted and keep the default ZIP limits unless the caller has a justified larger bound.
 
 ## Multi-Section Documents
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,9 @@ import {
   MarkdownDocxPatch,
   Options,
   PatchMarkdownOptions,
+  ReferenceDocxBytes,
   ReferenceDocxInput,
+  ReferenceDocxGenerationOptions,
   SectionConfig,
   Style,
 } from "./types.js";
@@ -45,6 +47,11 @@ import {
   throwIfAborted,
   yieldToAbortSignal,
 } from "./processingLimits.js";
+import {
+  applyReferenceDocxPresentation,
+  buildReferenceConversionOptions,
+  loadReferenceDocx,
+} from "./referenceDocx.js";
 
 const defaultStyle: Style = {
   titleSize: 32,
@@ -92,7 +99,16 @@ export {
   MermaidRenderingOptions,
   Options,
   PatchMarkdownOptions,
+  ReferenceDocxErrorCode,
+  ReferenceDocxErrorContext,
+  ReferenceDocxBytes,
+  ReferenceDocxGenerationOptions,
   ReferenceDocxInput,
+  ReferenceDocxModeOptions,
+  ReferenceDocxPackageLimits,
+  ReferenceDocxStyleMap,
+  ReferenceDocxStyleRole,
+  ReferenceDocxStyleSelector,
   RemoteImageHandlingOptions,
   SectionConfig,
   SectionTemplate,
@@ -149,6 +165,93 @@ export async function convertMarkdownToBuffer(
   options: Options = defaultOptions
 ): Promise<Buffer> {
   return Buffer.from(await convertMarkdownToArrayBuffer(markdown, options));
+}
+
+/**
+ * Generate a brand-new DOCX from Markdown while adopting presentation from a
+ * reference DOCX. Unlike patchMarkdownInDocx, reference body content and
+ * placeholders are never copied.
+ */
+export async function convertMarkdownWithReferenceDocx(
+  markdown: string,
+  referenceDocx: ReferenceDocxBytes,
+  options: ReferenceDocxGenerationOptions = {},
+): Promise<Blob> {
+  const bytes = await convertMarkdownWithReferenceDocxBytes(
+    markdown,
+    referenceDocx,
+    options,
+  );
+  return new Blob([bytes], {
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  });
+}
+
+export async function convertMarkdownWithReferenceDocxToArrayBuffer(
+  markdown: string,
+  referenceDocx: ReferenceDocxBytes,
+  options: ReferenceDocxGenerationOptions = {},
+): Promise<ArrayBuffer> {
+  const bytes = await convertMarkdownWithReferenceDocxBytes(
+    markdown,
+    referenceDocx,
+    options,
+  );
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+}
+
+export async function convertMarkdownWithReferenceDocxToBuffer(
+  markdown: string,
+  referenceDocx: ReferenceDocxBytes,
+  options: ReferenceDocxGenerationOptions = {},
+): Promise<Buffer> {
+  return Buffer.from(
+    await convertMarkdownWithReferenceDocxToArrayBuffer(
+      markdown,
+      referenceDocx,
+      options,
+    ),
+  );
+}
+
+async function convertMarkdownWithReferenceDocxBytes(
+  markdown: string,
+  referenceDocx: ReferenceDocxBytes,
+  options: ReferenceDocxGenerationOptions,
+): Promise<Uint8Array> {
+  try {
+    const reference = await loadReferenceDocx(
+      referenceDocx,
+      options.reference,
+      options.signal,
+    );
+    const conversionOptions = buildReferenceConversionOptions(options, reference);
+    const generated = await convertMarkdownToArrayBuffer(
+      markdown,
+      conversionOptions,
+    );
+    return applyReferenceDocxPresentation(
+      generated,
+      reference,
+      options.reference,
+      options.signal,
+    );
+  } catch (error) {
+    if (error instanceof MarkdownConversionError) throw error;
+    throw new MarkdownConversionError(
+      `Failed to generate DOCX from reference: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+      {
+        phase: "reference-docx",
+        code: "INVALID_PACKAGE",
+        originalError: error,
+      },
+    );
+  }
 }
 
 /**

--- a/src/referenceDocx.ts
+++ b/src/referenceDocx.ts
@@ -624,7 +624,10 @@ function resolveStyleMap(
         .find(Boolean);
       if (!style) {
         for (const name of candidates.names) {
-          style = resolveStyleByName(styles, name, duplicateBehavior, role);
+          // Automatic conventional-name lookup is deterministic by document
+          // order. The caller-controlled duplicate policy applies only to an
+          // explicit { name } selector, where ambiguity should be surfaced.
+          style = resolveStyleByName(styles, name, "first", role);
           if (style) break;
         }
       }

--- a/src/referenceDocx.ts
+++ b/src/referenceDocx.ts
@@ -1,0 +1,1472 @@
+import JSZip from "jszip";
+import { MarkdownConversionError } from "./errors.js";
+import { yieldToAbortSignal } from "./processingLimits.js";
+import type {
+  Options,
+  ReferenceDocxErrorCode,
+  ReferenceDocxErrorContext,
+  ReferenceDocxGenerationOptions,
+  ReferenceDocxBytes,
+  ReferenceDocxModeOptions,
+  ReferenceDocxPackageLimits,
+  ReferenceDocxStyleRole,
+  ReferenceDocxStyleSelector,
+  SectionPageConfig,
+} from "./types.js";
+
+const DEFAULT_LIMITS: Required<ReferenceDocxPackageLimits> = {
+  maxCompressedBytes: 16 * 1024 * 1024,
+  maxUncompressedBytes: 64 * 1024 * 1024,
+  maxEntryUncompressedBytes: 16 * 1024 * 1024,
+  maxEntries: 512,
+};
+
+const REQUIRED_PARTS = [
+  "[Content_Types].xml",
+  "_rels/.rels",
+  "word/document.xml",
+  "word/_rels/document.xml.rels",
+  "word/styles.xml",
+] as const;
+
+const RELATIONSHIP_NS =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/";
+
+type StyleType = "paragraph" | "character" | "table" | string;
+
+interface ReferenceStyle {
+  id: string;
+  name?: string;
+  type: StyleType;
+  xml: string;
+}
+
+interface Relationship {
+  id: string;
+  type: string;
+  target: string;
+  targetMode?: string;
+  xml: string;
+}
+
+interface ContentTypes {
+  defaults: Map<string, string>;
+  overrides: Map<string, string>;
+}
+
+export interface LoadedReferenceDocx {
+  zip: JSZip;
+  contentTypesXml: string;
+  documentXml: string;
+  documentRelationshipsXml: string;
+  stylesXml: string;
+  numberingXml?: string;
+  finalSectionProperties?: string;
+  page?: SectionPageConfig;
+}
+
+const AUTO_STYLE_CANDIDATES: Record<
+  ReferenceDocxStyleRole,
+  { ids: string[]; names: string[] }
+> = {
+  normal: { ids: ["Normal"], names: ["Normal"] },
+  title: { ids: ["Title"], names: ["Title"] },
+  heading1: { ids: ["Heading1"], names: ["Heading 1", "heading 1"] },
+  heading2: { ids: ["Heading2"], names: ["Heading 2", "heading 2"] },
+  heading3: { ids: ["Heading3"], names: ["Heading 3", "heading 3"] },
+  heading4: { ids: ["Heading4"], names: ["Heading 4", "heading 4"] },
+  heading5: { ids: ["Heading5"], names: ["Heading 5", "heading 5"] },
+  heading6: { ids: ["Heading6"], names: ["Heading 6", "heading 6"] },
+  blockquote: {
+    ids: ["BlockQuote", "Quote", "IntenseQuote"],
+    names: ["Block Quote", "Quote", "Intense Quote"],
+  },
+  codeBlock: {
+    ids: ["CodeBlock", "Code"],
+    names: ["Code Block", "Code"],
+  },
+  caption: { ids: ["Caption"], names: ["Caption"] },
+  listParagraph: {
+    ids: ["ListParagraph"],
+    names: ["List Paragraph"],
+  },
+  table: {
+    ids: ["TableNormal"],
+    names: ["Normal Table", "Table Normal"],
+  },
+  strong: { ids: ["Strong"], names: ["Strong"] },
+  emphasis: { ids: ["Emphasis"], names: ["Emphasis"] },
+  inlineCode: {
+    ids: ["InlineCode", "CodeChar"],
+    names: ["Inline Code", "Code Char"],
+  },
+  hyperlink: { ids: ["Hyperlink"], names: ["Hyperlink"] },
+};
+
+const PARAGRAPH_ROLES = new Set<ReferenceDocxStyleRole>([
+  "normal",
+  "title",
+  "heading1",
+  "heading2",
+  "heading3",
+  "heading4",
+  "heading5",
+  "heading6",
+  "blockquote",
+  "codeBlock",
+  "caption",
+  "listParagraph",
+]);
+
+const CHARACTER_ROLES = new Set<ReferenceDocxStyleRole>([
+  "strong",
+  "emphasis",
+  "inlineCode",
+  "hyperlink",
+]);
+
+function referenceError(
+  message: string,
+  code: ReferenceDocxErrorCode,
+  details: Omit<ReferenceDocxErrorContext, "phase" | "code"> = {},
+): MarkdownConversionError {
+  return new MarkdownConversionError(message, {
+    phase: "reference-docx",
+    code,
+    ...details,
+  } satisfies ReferenceDocxErrorContext);
+}
+
+function throwIfReferenceAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw referenceError("Reference DOCX generation was aborted", "ABORTED", {
+      originalError: signal.reason,
+    });
+  }
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw referenceError(
+      `${name} must be a positive safe integer`,
+      "INVALID_INPUT",
+      { actual: value },
+    );
+  }
+}
+
+function resolveLimits(
+  limits: ReferenceDocxPackageLimits | undefined,
+): Required<ReferenceDocxPackageLimits> {
+  const resolved = { ...DEFAULT_LIMITS, ...(limits || {}) };
+  for (const [name, value] of Object.entries(resolved)) {
+    validatePositiveInteger(value, `reference.limits.${name}`);
+  }
+  return resolved;
+}
+
+async function inputToBytes(
+  input: ReferenceDocxBytes,
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  throwIfReferenceAborted(signal);
+
+  if (input instanceof ArrayBuffer) {
+    return new Uint8Array(input);
+  }
+  if (ArrayBuffer.isView(input)) {
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  }
+  if (typeof Blob !== "undefined" && input instanceof Blob) {
+    const bytes = new Uint8Array(await input.arrayBuffer());
+    throwIfReferenceAborted(signal);
+    return bytes;
+  }
+
+  throw referenceError(
+    "Reference DOCX must be provided as Buffer, Uint8Array, ArrayBuffer, or Blob bytes",
+    "INVALID_INPUT",
+  );
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function encodeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function getAttribute(xml: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = xml.match(
+    new RegExp(`(?:\\s|<)${escapedName}\\s*=\\s*(["'])(.*?)\\1`),
+  );
+  return match ? decodeXml(match[2]) : undefined;
+}
+
+function replaceAttribute(xml: string, name: string, value: string): string {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`(${escapedName}\\s*=\\s*)(["'])(.*?)\\2`);
+  if (pattern.test(xml)) {
+    return xml.replace(pattern, `$1"${encodeXml(value)}"`);
+  }
+  return xml.replace(/\s*\/>$/, ` ${name}="${encodeXml(value)}"/>`);
+}
+
+function assertSafeXml(xml: string, entry: string): void {
+  if (/<!DOCTYPE|<!ENTITY/i.test(xml)) {
+    throw referenceError(
+      `Reference DOCX XML part ${entry} contains a prohibited DTD or entity declaration`,
+      "MALFORMED_XML",
+      { entry },
+    );
+  }
+}
+
+async function readXml(zip: JSZip, entry: string): Promise<string> {
+  const file = zip.file(entry);
+  if (!file) {
+    throw referenceError(
+      `Reference DOCX is missing required package part ${entry}`,
+      "MISSING_PACKAGE_PART",
+      { entry },
+    );
+  }
+  let xml: string;
+  try {
+    xml = await file.async("string");
+  } catch (error) {
+    throw referenceError(
+      `Reference DOCX package part ${entry} could not be decompressed`,
+      "INVALID_ZIP",
+      { entry, originalError: error },
+    );
+  }
+  assertSafeXml(xml, entry);
+  return xml;
+}
+
+function unsafeEntryReason(name: string): boolean {
+  let decoded = name;
+  try {
+    decoded = decodeURIComponent(name);
+  } catch {
+    return true;
+  }
+  const normalized = decoded.replace(/\\/g, "/");
+  return (
+    decoded.includes("\\") ||
+    normalized.startsWith("/") ||
+    /^[A-Za-z]:/.test(normalized) ||
+    normalized.includes("\0") ||
+    normalized.split("/").some((segment) => segment === "..")
+  );
+}
+
+function validateZipEntries(
+  zip: JSZip,
+  limits: Required<ReferenceDocxPackageLimits>,
+): void {
+  const entries = Object.values(zip.files);
+  if (entries.length > limits.maxEntries) {
+    throw referenceError(
+      `Reference DOCX contains ${entries.length} ZIP entries; limit is ${limits.maxEntries}`,
+      "PACKAGE_LIMIT_EXCEEDED",
+      { limit: limits.maxEntries, actual: entries.length },
+    );
+  }
+
+  let totalUncompressed = 0;
+  for (const entry of entries) {
+    const metadata = entry as typeof entry & {
+      unsafeOriginalName?: string;
+      _data?: { uncompressedSize?: number; compressedSize?: number };
+    };
+    const originalName = metadata.unsafeOriginalName ?? entry.name;
+    if (
+      originalName !== entry.name ||
+      unsafeEntryReason(originalName) ||
+      unsafeEntryReason(entry.name)
+    ) {
+      throw referenceError(
+        `Reference DOCX contains an unsafe ZIP entry path: ${originalName}`,
+        "UNSAFE_ENTRY_PATH",
+        { entry: originalName },
+      );
+    }
+
+    const size = metadata._data?.uncompressedSize ?? 0;
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw referenceError(
+        `Reference DOCX has invalid size metadata for ${entry.name}`,
+        "INVALID_ZIP",
+        { entry: entry.name, actual: size },
+      );
+    }
+    if (size > limits.maxEntryUncompressedBytes) {
+      throw referenceError(
+        `Reference DOCX entry ${entry.name} exceeds the uncompressed entry limit`,
+        "PACKAGE_LIMIT_EXCEEDED",
+        {
+          entry: entry.name,
+          limit: limits.maxEntryUncompressedBytes,
+          actual: size,
+        },
+      );
+    }
+    totalUncompressed += size;
+    if (totalUncompressed > limits.maxUncompressedBytes) {
+      throw referenceError(
+        "Reference DOCX exceeds the total uncompressed package limit",
+        "PACKAGE_LIMIT_EXCEEDED",
+        { limit: limits.maxUncompressedBytes, actual: totalUncompressed },
+      );
+    }
+  }
+}
+
+function extractFinalSectionProperties(documentXml: string): string | undefined {
+  const matches = Array.from(
+    documentXml.matchAll(/<w:sectPr\b[\s\S]*?<\/w:sectPr>/g),
+    (match) => match[0],
+  );
+  return matches.at(-1);
+}
+
+function numericAttribute(xml: string, name: string): number | undefined {
+  const value = getAttribute(xml, name);
+  if (value === undefined || !/^\d+$/.test(value)) {
+    return undefined;
+  }
+  return Number(value);
+}
+
+function extractPageConfig(
+  sectionProperties: string | undefined,
+): SectionPageConfig | undefined {
+  if (!sectionProperties) return undefined;
+  const pageSize = sectionProperties.match(/<w:pgSz\b[^>]*\/?\s*>/)?.[0];
+  const pageMargin = sectionProperties.match(/<w:pgMar\b[^>]*\/?\s*>/)?.[0];
+  if (!pageSize && !pageMargin) return undefined;
+
+  return {
+    ...(pageSize
+      ? {
+          size: {
+            width: numericAttribute(pageSize, "w:w"),
+            height: numericAttribute(pageSize, "w:h"),
+            orientation:
+              getAttribute(pageSize, "w:orient") === "landscape"
+                ? ("LANDSCAPE" as const)
+                : ("PORTRAIT" as const),
+          },
+        }
+      : {}),
+    ...(pageMargin
+      ? {
+          margin: {
+            top: numericAttribute(pageMargin, "w:top"),
+            right: numericAttribute(pageMargin, "w:right"),
+            bottom: numericAttribute(pageMargin, "w:bottom"),
+            left: numericAttribute(pageMargin, "w:left"),
+            header: numericAttribute(pageMargin, "w:header"),
+            footer: numericAttribute(pageMargin, "w:footer"),
+            gutter: numericAttribute(pageMargin, "w:gutter"),
+          },
+        }
+      : {}),
+  };
+}
+
+export async function loadReferenceDocx(
+  input: ReferenceDocxBytes,
+  mode: ReferenceDocxModeOptions = {},
+  signal?: AbortSignal,
+): Promise<LoadedReferenceDocx> {
+  try {
+    const limits = resolveLimits(mode.limits);
+    const bytes = await inputToBytes(input, signal);
+    if (bytes.byteLength > limits.maxCompressedBytes) {
+      throw referenceError(
+        "Reference DOCX exceeds the compressed package limit",
+        "PACKAGE_LIMIT_EXCEEDED",
+        { limit: limits.maxCompressedBytes, actual: bytes.byteLength },
+      );
+    }
+    if (bytes.byteLength < 4) {
+      throw referenceError("Reference DOCX is not a valid ZIP package", "INVALID_ZIP");
+    }
+
+    let zip: JSZip;
+    try {
+      zip = await JSZip.loadAsync(bytes, { createFolders: false });
+    } catch (error) {
+      throw referenceError("Reference DOCX is not a valid ZIP package", "INVALID_ZIP", {
+        originalError: error,
+      });
+    }
+    throwIfReferenceAborted(signal);
+    validateZipEntries(zip, limits);
+    for (const entry of REQUIRED_PARTS) {
+      if (!zip.file(entry)) {
+        throw referenceError(
+          `Reference DOCX is missing required package part ${entry}`,
+          "MISSING_PACKAGE_PART",
+          { entry },
+        );
+      }
+    }
+
+    const [contentTypesXml, rootRelsXml, documentXml, documentRelationshipsXml, stylesXml] =
+      await Promise.all([
+        readXml(zip, "[Content_Types].xml"),
+        readXml(zip, "_rels/.rels"),
+        readXml(zip, "word/document.xml"),
+        readXml(zip, "word/_rels/document.xml.rels"),
+        readXml(zip, "word/styles.xml"),
+      ]);
+    throwIfReferenceAborted(signal);
+
+    if (
+      !/wordprocessingml\.document\.main\+xml/.test(contentTypesXml) ||
+      !/relationships\/officeDocument/.test(rootRelsXml) ||
+      !/<w:document\b/.test(documentXml) ||
+      !/<w:styles\b/.test(stylesXml)
+    ) {
+      throw referenceError(
+        "Reference ZIP is not a valid WordprocessingML DOCX package",
+        "INVALID_PACKAGE",
+      );
+    }
+
+    const numberingXml = zip.file("word/numbering.xml")
+      ? await readXml(zip, "word/numbering.xml")
+      : undefined;
+    const finalSectionProperties = extractFinalSectionProperties(documentXml);
+
+    return {
+      zip,
+      contentTypesXml,
+      documentXml,
+      documentRelationshipsXml,
+      stylesXml,
+      numberingXml,
+      finalSectionProperties,
+      page: extractPageConfig(finalSectionProperties),
+    };
+  } catch (error) {
+    if (error instanceof MarkdownConversionError) throw error;
+    throw referenceError("Failed to inspect reference DOCX package", "INVALID_PACKAGE", {
+      originalError: error,
+    });
+  }
+}
+
+export function buildReferenceConversionOptions(
+  options: ReferenceDocxGenerationOptions,
+  reference: LoadedReferenceDocx,
+): Options {
+  const { reference: mode, ...conversionOptions } = options;
+  if ((mode?.preservePageLayout ?? true) && reference.page) {
+    const page = reference.page;
+    conversionOptions.template = {
+      ...(conversionOptions.template || {}),
+      page,
+    };
+    if (conversionOptions.sections) {
+      conversionOptions.sections = conversionOptions.sections.map((section) => ({
+        ...section,
+        page,
+      }));
+    }
+  }
+  return conversionOptions;
+}
+
+function parseStyles(stylesXml: string): ReferenceStyle[] {
+  const styles = Array.from(
+    stylesXml.matchAll(/<w:style\b[\s\S]*?<\/w:style>/g),
+    (match) => {
+      const xml = match[0];
+      const open = xml.match(/^<w:style\b[^>]*>/)?.[0] ?? xml;
+      const nameElement = xml.match(/<w:name\b[^>]*\/?\s*>/)?.[0];
+      return {
+        id: getAttribute(open, "w:styleId") ?? "",
+        type: getAttribute(open, "w:type") ?? "paragraph",
+        name: nameElement ? getAttribute(nameElement, "w:val") : undefined,
+        xml,
+      };
+    },
+  );
+
+  const seen = new Set<string>();
+  for (const style of styles) {
+    if (!style.id || seen.has(style.id)) {
+      throw referenceError(
+        `Reference styles.xml contains a missing or duplicate style ID: ${style.id || "(empty)"}`,
+        "MALFORMED_XML",
+        { entry: "word/styles.xml" },
+      );
+    }
+    seen.add(style.id);
+  }
+  return styles;
+}
+
+function expectedStyleType(role: ReferenceDocxStyleRole): StyleType {
+  if (PARAGRAPH_ROLES.has(role)) return "paragraph";
+  if (CHARACTER_ROLES.has(role)) return "character";
+  return "table";
+}
+
+function resolveStyleByName(
+  styles: ReferenceStyle[],
+  name: string,
+  duplicateBehavior: "first" | "throw",
+  role: ReferenceDocxStyleRole,
+  selector?: ReferenceDocxStyleSelector,
+): ReferenceStyle | undefined {
+  const matches = styles.filter((style) => style.name === name);
+  if (matches.length > 1 && duplicateBehavior === "throw") {
+    throw referenceError(
+      `Reference DOCX style name ${name} is duplicated; select by style ID or set duplicateStyleNameBehavior to "first"`,
+      "DUPLICATE_STYLE_NAME",
+      { role, selector: selector ?? { name } },
+    );
+  }
+  return matches[0];
+}
+
+function validateResolvedStyle(
+  role: ReferenceDocxStyleRole,
+  selector: ReferenceDocxStyleSelector | undefined,
+  style: ReferenceStyle | undefined,
+  missingBehavior: "fallback" | "throw",
+  explicit: boolean,
+): ReferenceStyle | undefined {
+  if (!style) {
+    if (explicit && missingBehavior === "throw") {
+      throw referenceError(
+        `Reference DOCX style for ${role} could not be found`,
+        "MISSING_STYLE",
+        { role, selector },
+      );
+    }
+    return undefined;
+  }
+  const expected = expectedStyleType(role);
+  if (style.type !== expected) {
+    if (!explicit || missingBehavior === "fallback") return undefined;
+    throw referenceError(
+      `Reference style ${style.id} has type ${style.type}; ${role} requires ${expected}`,
+      "STYLE_TYPE_MISMATCH",
+      { role, selector: selector ?? { id: style.id } },
+    );
+  }
+  return style;
+}
+
+function resolveStyleMap(
+  styles: ReferenceStyle[],
+  mode: ReferenceDocxModeOptions,
+): Partial<Record<ReferenceDocxStyleRole, string>> {
+  const resolved: Partial<Record<ReferenceDocxStyleRole, string>> = {};
+  const missingBehavior = mode.missingStyleBehavior ?? "fallback";
+  const duplicateBehavior = mode.duplicateStyleNameBehavior ?? "throw";
+
+  for (const role of Object.keys(AUTO_STYLE_CANDIDATES) as ReferenceDocxStyleRole[]) {
+    const explicitSelector = mode.styles?.[role];
+    if (explicitSelector === null) continue;
+    const explicit = explicitSelector !== undefined;
+    let style: ReferenceStyle | undefined;
+
+    if (explicitSelector) {
+      const hasId = typeof explicitSelector.id === "string";
+      const hasName = typeof explicitSelector.name === "string";
+      if (hasId === hasName) {
+        throw referenceError(
+          `Reference style selector for ${role} must specify exactly one of id or name`,
+          "INVALID_INPUT",
+          { role, selector: explicitSelector },
+        );
+      }
+      const selectedValue = hasId ? explicitSelector.id : explicitSelector.name;
+      if (!selectedValue || selectedValue.trim().length === 0) {
+        throw referenceError(
+          `Reference style selector for ${role} must not be empty`,
+          "INVALID_INPUT",
+          { role, selector: explicitSelector },
+        );
+      }
+      style = hasId
+        ? styles.find((candidate) => candidate.id === explicitSelector.id)
+        : resolveStyleByName(
+            styles,
+            explicitSelector.name as string,
+            duplicateBehavior,
+            role,
+            explicitSelector,
+          );
+    } else {
+      const candidates = AUTO_STYLE_CANDIDATES[role];
+      style = candidates.ids
+        .map((id) => styles.find((candidate) => candidate.id === id))
+        .find(Boolean);
+      if (!style) {
+        for (const name of candidates.names) {
+          style = resolveStyleByName(styles, name, duplicateBehavior, role);
+          if (style) break;
+        }
+      }
+    }
+
+    const valid = validateResolvedStyle(
+      role,
+      explicitSelector ?? undefined,
+      style,
+      missingBehavior,
+      explicit,
+    );
+    if (valid) resolved[role] = valid.id;
+  }
+  return resolved;
+}
+
+function idsFromXml(xml: string, pattern: RegExp): number[] {
+  return Array.from(xml.matchAll(pattern), (match) => Number(match[1])).filter(
+    Number.isSafeInteger,
+  );
+}
+
+function remapReferenceNumbering(
+  generatedNumberingXml: string,
+  referenceNumberingXml: string | undefined,
+): { xml: string; numIdMap: Map<number, number> } {
+  const numIdMap = new Map<number, number>();
+  if (!referenceNumberingXml) {
+    return { xml: generatedNumberingXml, numIdMap };
+  }
+
+  const generatedAbstractIds = idsFromXml(
+    generatedNumberingXml,
+    /<w:abstractNum\b[^>]*w:abstractNumId="(\d+)"/g,
+  );
+  const generatedNumIds = idsFromXml(
+    generatedNumberingXml,
+    /<w:num\b[^>]*w:numId="(\d+)"/g,
+  );
+  let nextAbstractId = Math.max(0, ...generatedAbstractIds) + 1;
+  let nextNumId = Math.max(0, ...generatedNumIds) + 1;
+  const abstractIdMap = new Map<number, number>();
+
+  const abstractDefinitions = Array.from(
+    referenceNumberingXml.matchAll(/<w:abstractNum\b[\s\S]*?<\/w:abstractNum>/g),
+    (match) => match[0],
+  ).map((definition) => {
+    const id = Number(
+      getAttribute(definition.match(/^<w:abstractNum\b[^>]*>/)?.[0] ?? definition, "w:abstractNumId"),
+    );
+    if (!Number.isSafeInteger(id)) {
+      throw referenceError(
+        "Reference numbering.xml contains an invalid abstract numbering ID",
+        "MALFORMED_XML",
+        { entry: "word/numbering.xml" },
+      );
+    }
+    const mapped = nextAbstractId++;
+    abstractIdMap.set(id, mapped);
+    return replaceAttribute(definition, "w:abstractNumId", String(mapped));
+  });
+
+  const numDefinitions = Array.from(
+    referenceNumberingXml.matchAll(/<w:num\b[\s\S]*?<\/w:num>/g),
+    (match) => match[0],
+  ).map((definition) => {
+    const open = definition.match(/^<w:num\b[^>]*>/)?.[0] ?? definition;
+    const id = Number(getAttribute(open, "w:numId"));
+    const abstractElement = definition.match(/<w:abstractNumId\b[^>]*\/?\s*>/)?.[0];
+    const abstractId = Number(
+      abstractElement ? getAttribute(abstractElement, "w:val") : undefined,
+    );
+    if (!Number.isSafeInteger(id) || !abstractIdMap.has(abstractId)) {
+      throw referenceError(
+        "Reference numbering.xml contains an invalid numbering definition",
+        "MALFORMED_XML",
+        { entry: "word/numbering.xml" },
+      );
+    }
+    const mapped = nextNumId++;
+    numIdMap.set(id, mapped);
+    let rewritten = replaceAttribute(definition, "w:numId", String(mapped));
+    rewritten = rewritten.replace(
+      /<w:abstractNumId\b[^>]*\/?\s*>/,
+      (element) => replaceAttribute(element, "w:val", String(abstractIdMap.get(abstractId))),
+    );
+    return rewritten;
+  });
+
+  const additions = [...abstractDefinitions, ...numDefinitions].join("");
+  return {
+    xml: generatedNumberingXml.replace("</w:numbering>", `${additions}</w:numbering>`),
+    numIdMap,
+  };
+}
+
+function rewriteStyleNumbering(
+  stylesXml: string,
+  numIdMap: Map<number, number>,
+): string {
+  if (numIdMap.size === 0) return stylesXml;
+  return stylesXml.replace(/<w:numId\b[^>]*\/?\s*>/g, (element) => {
+    const id = Number(getAttribute(element, "w:val"));
+    const mapped = numIdMap.get(id);
+    return mapped === undefined
+      ? element
+      : replaceAttribute(element, "w:val", String(mapped));
+  });
+}
+
+function mergeStyles(referenceStylesXml: string, generatedStylesXml: string): string {
+  const referenceStyles = parseStyles(referenceStylesXml);
+  const referenceIds = new Set(referenceStyles.map((style) => style.id));
+  const generatedStyles = Array.from(
+    generatedStylesXml.matchAll(/<w:style\b[\s\S]*?<\/w:style>/g),
+    (match) => match[0],
+  );
+  const appended: string[] = [];
+  for (const xml of generatedStyles) {
+    const open = xml.match(/^<w:style\b[^>]*>/)?.[0] ?? xml;
+    const id = getAttribute(open, "w:styleId");
+    if (id && !referenceIds.has(id)) {
+      referenceIds.add(id);
+      appended.push(xml);
+    }
+  }
+  if (!referenceStylesXml.includes("</w:styles>")) {
+    throw referenceError(
+      "Reference styles.xml is malformed",
+      "MALFORMED_XML",
+      { entry: "word/styles.xml" },
+    );
+  }
+  return referenceStylesXml.replace(
+    "</w:styles>",
+    `${appended.join("")}</w:styles>`,
+  );
+}
+
+function replaceParagraphStyle(paragraph: string, styleId: string): string {
+  const styleElement = `<w:pStyle w:val="${encodeXml(styleId)}"/>`;
+  const pPrMatch = paragraph.match(/<w:pPr\b[^>]*>[\s\S]*?<\/w:pPr>/);
+  if (!pPrMatch) {
+    return paragraph.replace(/^(<w:p\b[^>]*>)/, `$1<w:pPr>${styleElement}</w:pPr>`);
+  }
+  let pPr = pPrMatch[0].replace(/<w:pStyle\b[^>]*\/?\s*>/g, "");
+  pPr = pPr.replace(/^(<w:pPr\b[^>]*>)/, `$1${styleElement}`);
+  return paragraph.replace(pPrMatch[0], pPr);
+}
+
+function stripParagraphDirectFormatting(paragraph: string): string {
+  return paragraph.replace(
+    /<w:pPr\b[^>]*>[\s\S]*?<\/w:pPr>/,
+    (pPr) => {
+      let rewritten = pPr;
+      for (const tag of [
+        "bidi",
+        "spacing",
+        "jc",
+        "pBdr",
+        "shd",
+        "ind",
+        "keepNext",
+        "keepLines",
+        "widowControl",
+      ]) {
+        rewritten = rewritten.replace(
+          new RegExp(
+            `<w:${tag}\\b(?:[^>]*\\/>|[^>]*>[\\s\\S]*?<\\/w:${tag}>)`,
+            "g",
+          ),
+          "",
+        );
+      }
+      return rewritten;
+    },
+  );
+}
+
+function stripBaseRunFormatting(run: string): string {
+  return run.replace(
+    /<w:(?:color|sz|szCs|rFonts|rtl)\b[^>]*\/?\s*>/g,
+    "",
+  );
+}
+
+function replaceRunStyle(run: string, styleId: string): string {
+  const styleElement = `<w:rStyle w:val="${encodeXml(styleId)}"/>`;
+  const rPrMatch = run.match(/<w:rPr\b[^>]*>[\s\S]*?<\/w:rPr>/);
+  if (!rPrMatch) {
+    return run.replace(/^(<w:r\b[^>]*>)/, `$1<w:rPr>${styleElement}</w:rPr>`);
+  }
+  let rPr = rPrMatch[0].replace(/<w:rStyle\b[^>]*\/?\s*>/g, "");
+  rPr = rPr.replace(/^(<w:rPr\b[^>]*>)/, `$1${styleElement}`);
+  return run.replace(rPrMatch[0], rPr);
+}
+
+function applyRunStyles(
+  paragraph: string,
+  styleMap: Partial<Record<ReferenceDocxStyleRole, string>>,
+): string {
+  let rewritten = paragraph;
+  if (styleMap.hyperlink) {
+    rewritten = rewritten.replace(
+      /<w:hyperlink\b[\s\S]*?<\/w:hyperlink>/g,
+      (hyperlink) =>
+        hyperlink.replace(/<w:r\b[\s\S]*?<\/w:r>/g, (run) =>
+          replaceRunStyle(run, styleMap.hyperlink!),
+        ),
+    );
+  }
+  return rewritten.replace(/<w:r\b[\s\S]*?<\/w:r>/g, (originalRun) => {
+    let run = originalRun;
+    const isInlineCode =
+      /<w:shd\b/.test(run) ||
+      /<w:rFonts\b[^>]*(?:Courier|Consolas|monospace)/i.test(run);
+    const isStrong = /<w:b\b/.test(run);
+    const isEmphasis = /<w:i\b/.test(run);
+    const existingStyle = run.match(/<w:rStyle\b[^>]*w:val=["']([^"']+)["']/)?.[1];
+    const isHyperlink =
+      existingStyle === "Hyperlink" || existingStyle === styleMap.hyperlink;
+
+    const role: ReferenceDocxStyleRole | undefined = isInlineCode
+      ? "inlineCode"
+      : isHyperlink
+        ? "hyperlink"
+        : isStrong
+          ? "strong"
+          : isEmphasis
+            ? "emphasis"
+            : undefined;
+    if (role && styleMap[role]) {
+      run = replaceRunStyle(run, styleMap[role]);
+      if (role === "inlineCode") {
+        run = run.replace(/<w:(?:shd|rFonts|color|sz|szCs)\b[^>]*\/?\s*>/g, "");
+      }
+    }
+    return run;
+  });
+}
+
+function paragraphRole(paragraph: string): ReferenceDocxStyleRole | undefined {
+  const pPr = paragraph.match(/<w:pPr\b[^>]*>[\s\S]*?<\/w:pPr>/)?.[0] ?? "";
+  const styleIds = Array.from(
+    pPr.matchAll(/<w:pStyle\b[^>]*w:val=["']([^"']+)["']/g),
+    (match) => match[1],
+  );
+  for (let level = 1; level <= 6; level++) {
+    if (styleIds.includes(`Heading${level}`) || styleIds.includes(String(level))) {
+      return `heading${level}` as ReferenceDocxStyleRole;
+    }
+  }
+  if (styleIds.includes("Title")) return "title";
+  if (styleIds.includes("Caption")) return "caption";
+  if (styleIds.includes("ListParagraph")) return "listParagraph";
+  if (/<w:shd\b/.test(pPr)) return "codeBlock";
+  if (/<w:pBdr\b/.test(pPr)) return "blockquote";
+  if (styleIds.length === 0) return "normal";
+  return undefined;
+}
+
+function applyStyleMapToDocument(
+  documentXml: string,
+  styleMap: Partial<Record<ReferenceDocxStyleRole, string>>,
+): string {
+  let rewritten = documentXml.replace(/<w:p\b[\s\S]*?<\/w:p>/g, (paragraph) => {
+    const role = paragraphRole(paragraph);
+    const styleId = role ? styleMap[role] : undefined;
+    let output = paragraph;
+    if (styleId) {
+      output = replaceParagraphStyle(output, styleId);
+      output = stripParagraphDirectFormatting(output);
+      output = output.replace(/<w:r\b[\s\S]*?<\/w:r>/g, stripBaseRunFormatting);
+    }
+    return applyRunStyles(output, styleMap);
+  });
+
+  const tableStyle = styleMap.table;
+  if (tableStyle) {
+    rewritten = rewritten.replace(/<w:tbl\b[\s\S]*?<\/w:tbl>/g, (table) => {
+      const tblPrMatch = table.match(/<w:tblPr\b[^>]*>[\s\S]*?<\/w:tblPr>/);
+      const styleElement = `<w:tblStyle w:val="${encodeXml(tableStyle)}"/>`;
+      if (!tblPrMatch) {
+        return table.replace(/^(<w:tbl\b[^>]*>)/, `$1<w:tblPr>${styleElement}</w:tblPr>`);
+      }
+      let tblPr = tblPrMatch[0].replace(/<w:tblStyle\b[^>]*\/?\s*>/g, "");
+      tblPr = tblPr.replace(/^(<w:tblPr\b[^>]*>)/, `$1${styleElement}`);
+      return table.replace(tblPrMatch[0], tblPr);
+    });
+  }
+  return rewritten;
+}
+
+function parseRelationships(xml: string, entry: string): Relationship[] {
+  if (!/<Relationships\b/.test(xml)) {
+    throw referenceError(`Relationship part ${entry} is malformed`, "MALFORMED_XML", {
+      entry,
+    });
+  }
+  return Array.from(xml.matchAll(/<Relationship\b[^>]*\/?\s*>/g), (match) => {
+    const relation = match[0];
+    const id = getAttribute(relation, "Id");
+    const type = getAttribute(relation, "Type");
+    const target = getAttribute(relation, "Target");
+    if (!id || !type || !target) {
+      throw referenceError(`Relationship part ${entry} is malformed`, "MALFORMED_XML", {
+        entry,
+      });
+    }
+    return {
+      id,
+      type,
+      target,
+      targetMode: getAttribute(relation, "TargetMode"),
+      xml: relation,
+    };
+  });
+}
+
+function parseContentTypes(xml: string): ContentTypes {
+  const defaults = new Map<string, string>();
+  const overrides = new Map<string, string>();
+  for (const match of xml.matchAll(/<Default\b[^>]*\/?\s*>/g)) {
+    const extension = getAttribute(match[0], "Extension");
+    const contentType = getAttribute(match[0], "ContentType");
+    if (extension && contentType) defaults.set(extension.toLowerCase(), contentType);
+  }
+  for (const match of xml.matchAll(/<Override\b[^>]*\/?\s*>/g)) {
+    const partName = getAttribute(match[0], "PartName");
+    const contentType = getAttribute(match[0], "ContentType");
+    if (partName && contentType) overrides.set(partName, contentType);
+  }
+  return { defaults, overrides };
+}
+
+function relationshipPartPath(part: string): string {
+  const slash = part.lastIndexOf("/");
+  const directory = slash >= 0 ? part.slice(0, slash + 1) : "";
+  const basename = slash >= 0 ? part.slice(slash + 1) : part;
+  return `${directory}_rels/${basename}.rels`;
+}
+
+function resolvePartTarget(sourcePart: string, target: string): string {
+  if (unsafeEntryReason(target) || target.startsWith("/")) {
+    throw referenceError(
+      `Relationship target contains an unsafe package path: ${target}`,
+      "UNSAFE_ENTRY_PATH",
+      { entry: target },
+    );
+  }
+  const base = sourcePart.slice(0, sourcePart.lastIndexOf("/") + 1);
+  const segments = `${base}${target}`.split("/");
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (resolved.length === 0) {
+        throw referenceError(
+          `Relationship target escapes the DOCX package: ${target}`,
+          "UNSAFE_ENTRY_PATH",
+          { entry: target },
+        );
+      }
+      resolved.pop();
+    } else {
+      resolved.push(segment);
+    }
+  }
+  return resolved.join("/");
+}
+
+function relativeTarget(fromPart: string, toPart: string): string {
+  const from = fromPart.split("/").slice(0, -1);
+  const to = toPart.split("/");
+  let common = 0;
+  while (common < from.length && common < to.length && from[common] === to[common]) {
+    common++;
+  }
+  return `${"../".repeat(from.length - common)}${to.slice(common).join("/")}`;
+}
+
+function contentTypeForPart(types: ContentTypes, part: string): string | undefined {
+  const override = types.overrides.get(`/${part}`);
+  if (override) return override;
+  const extension = part.includes(".") ? part.split(".").pop()?.toLowerCase() : undefined;
+  return extension ? types.defaults.get(extension) : undefined;
+}
+
+function addContentType(
+  xml: string,
+  part: string,
+  contentType: string,
+): string {
+  const types = parseContentTypes(xml);
+  if (types.overrides.has(`/${part}`)) return xml;
+  const entry = `<Override PartName="/${encodeXml(part)}" ContentType="${encodeXml(contentType)}"/>`;
+  return xml.replace("</Types>", `${entry}</Types>`);
+}
+
+function addDefaultContentTypes(outputXml: string, referenceXml: string): string {
+  const output = parseContentTypes(outputXml);
+  const reference = parseContentTypes(referenceXml);
+  let rewritten = outputXml;
+  for (const [extension, contentType] of reference.defaults) {
+    if (!output.defaults.has(extension)) {
+      rewritten = rewritten.replace(
+        "</Types>",
+        `<Default Extension="${encodeXml(extension)}" ContentType="${encodeXml(contentType)}"/></Types>`,
+      );
+      output.defaults.set(extension, contentType);
+    }
+  }
+  return rewritten;
+}
+
+function nextRelationshipId(relationships: Relationship[]): string {
+  const used = new Set(relationships.map((relation) => relation.id));
+  let counter = 1;
+  while (used.has(`rIdReference${counter}`)) counter++;
+  return `rIdReference${counter}`;
+}
+
+function relationshipXml(relationship: Relationship): string {
+  return `<Relationship Id="${encodeXml(relationship.id)}" Type="${encodeXml(relationship.type)}" Target="${encodeXml(relationship.target)}"${
+    relationship.targetMode
+      ? ` TargetMode="${encodeXml(relationship.targetMode)}"`
+      : ""
+  }/>`;
+}
+
+function replaceOrAddRelationship(
+  xml: string,
+  relationship: Relationship,
+  existing?: Relationship,
+): string {
+  if (existing) return xml.replace(existing.xml, relationshipXml(relationship));
+  return xml.replace("</Relationships>", `${relationshipXml(relationship)}</Relationships>`);
+}
+
+async function importReferencePartGraph(
+  outputZip: JSZip,
+  reference: LoadedReferenceDocx,
+  sourcePart: string,
+  imported: Map<string, string>,
+  allowedInternalTypes: Set<string>,
+  signal?: AbortSignal,
+): Promise<string> {
+  const existing = imported.get(sourcePart);
+  if (existing) return existing;
+  if (unsafeEntryReason(sourcePart) || !reference.zip.file(sourcePart)) {
+    throw referenceError(
+      `Reference relationship target is missing or unsafe: ${sourcePart}`,
+      "MISSING_PACKAGE_PART",
+      { entry: sourcePart },
+    );
+  }
+
+  const destination = `word/reference-package/${sourcePart}`;
+  imported.set(sourcePart, destination);
+  const sourceFile = reference.zip.file(sourcePart);
+  const bytes = await sourceFile!.async("uint8array");
+  throwIfReferenceAborted(signal);
+  if (sourcePart.toLowerCase().endsWith(".xml")) {
+    assertSafeXml(new TextDecoder().decode(bytes), sourcePart);
+  }
+  outputZip.file(destination, bytes);
+
+  const referenceTypes = parseContentTypes(reference.contentTypesXml);
+  const contentType = contentTypeForPart(referenceTypes, sourcePart);
+  if (!contentType) {
+    throw referenceError(
+      `Reference package has no content type for ${sourcePart}`,
+      "INVALID_PACKAGE",
+      { entry: sourcePart },
+    );
+  }
+
+  const relsPath = relationshipPartPath(sourcePart);
+  const relsFile = reference.zip.file(relsPath);
+  if (relsFile) {
+    let relsXml = await readXml(reference.zip, relsPath);
+    const relationships = parseRelationships(relsXml, relsPath);
+    for (const relationship of relationships) {
+      const typeSuffix = relationship.type.slice(RELATIONSHIP_NS.length);
+      if (relationship.targetMode?.toLowerCase() === "external") {
+        if (typeSuffix !== "hyperlink") {
+          throw referenceError(
+            `Unsupported external reference relationship type: ${relationship.type}`,
+            "UNSUPPORTED_RELATIONSHIP",
+            { entry: relsPath, relationshipType: relationship.type },
+          );
+        }
+        continue;
+      }
+      if (!allowedInternalTypes.has(typeSuffix)) {
+        throw referenceError(
+          `Unsupported reference relationship type: ${relationship.type}`,
+          "UNSUPPORTED_RELATIONSHIP",
+          { entry: relsPath, relationshipType: relationship.type },
+        );
+      }
+      const targetPart = resolvePartTarget(sourcePart, relationship.target);
+      await importReferencePartGraph(
+        outputZip,
+        reference,
+        targetPart,
+        imported,
+        allowedInternalTypes,
+        signal,
+      );
+    }
+    outputZip.file(relationshipPartPath(destination), relsXml);
+  }
+
+  return destination;
+}
+
+function presentationTags(sectionProperties: string): string {
+  const names = [
+    "type",
+    "pgSz",
+    "pgMar",
+    "paperSrc",
+    "pgBorders",
+    "lnNumType",
+    "pgNumType",
+    "cols",
+    "formProt",
+    "vAlign",
+    "noEndnote",
+    "titlePg",
+    "textDirection",
+    "bidi",
+    "rtlGutter",
+    "docGrid",
+  ];
+  return names
+    .map((name) => {
+      const expression = new RegExp(
+        `<w:${name}\\b(?:[^>]*\\/>|[^>]*>[\\s\\S]*?<\\/w:${name}>)`,
+      );
+      return sectionProperties.match(expression)?.[0] ?? "";
+    })
+    .join("");
+}
+
+function removePresentationTags(sectionProperties: string): string {
+  let rewritten = sectionProperties;
+  for (const tag of [
+    "type",
+    "pgSz",
+    "pgMar",
+    "paperSrc",
+    "pgBorders",
+    "lnNumType",
+    "pgNumType",
+    "cols",
+    "formProt",
+    "vAlign",
+    "noEndnote",
+    "titlePg",
+    "textDirection",
+    "bidi",
+    "rtlGutter",
+    "docGrid",
+  ]) {
+    rewritten = rewritten.replace(
+      new RegExp(
+        `<w:${tag}\\b(?:[^>]*\\/>|[^>]*>[\\s\\S]*?<\\/w:${tag}>)`,
+        "g",
+      ),
+      "",
+    );
+  }
+  return rewritten;
+}
+
+async function adoptSectionPresentation(
+  documentXml: string,
+  outputZip: JSZip,
+  outputRelationshipsXml: string,
+  outputContentTypesXml: string,
+  reference: LoadedReferenceDocx,
+  mode: ReferenceDocxModeOptions,
+  signal?: AbortSignal,
+): Promise<{
+  documentXml: string;
+  relationshipsXml: string;
+  contentTypesXml: string;
+}> {
+  const section = reference.finalSectionProperties;
+  if (!section) {
+    return {
+      documentXml,
+      relationshipsXml: outputRelationshipsXml,
+      contentTypesXml: outputContentTypesXml,
+    };
+  }
+
+  let relationshipsXml = outputRelationshipsXml;
+  let contentTypesXml = addDefaultContentTypes(
+    outputContentTypesXml,
+    reference.contentTypesXml,
+  );
+  let outputRelationships = parseRelationships(
+    relationshipsXml,
+    "word/_rels/document.xml.rels",
+  );
+  const referenceRelationships = parseRelationships(
+    reference.documentRelationshipsXml,
+    "word/_rels/document.xml.rels",
+  );
+  const imported = new Map<string, string>();
+  const rewrittenHeaderFooterReferences: string[] = [];
+
+  if (mode.preserveHeadersAndFooters ?? true) {
+    const references = Array.from(
+      section.matchAll(/<w:(headerReference|footerReference)\b[^>]*\/?\s*>/g),
+      (match) => ({ kind: match[1], xml: match[0] }),
+    );
+    for (const referenceElement of references) {
+      const referenceId = getAttribute(referenceElement.xml, "r:id");
+      const relationship = referenceRelationships.find(
+        (candidate) => candidate.id === referenceId,
+      );
+      const expectedSuffix =
+        referenceElement.kind === "headerReference" ? "header" : "footer";
+      if (
+        !relationship ||
+        !relationship.type.endsWith(`/${expectedSuffix}`) ||
+        relationship.targetMode?.toLowerCase() === "external"
+      ) {
+        throw referenceError(
+          `Reference ${expectedSuffix} relationship is missing or unsupported`,
+          "UNSUPPORTED_RELATIONSHIP",
+          { relationshipType: relationship?.type },
+        );
+      }
+      const sourcePart = resolvePartTarget("word/document.xml", relationship.target);
+      const destination = await importReferencePartGraph(
+        outputZip,
+        reference,
+        sourcePart,
+        imported,
+        new Set(["image"]),
+        signal,
+      );
+      const id = nextRelationshipId(outputRelationships);
+      const importedRelationship: Relationship = {
+        id,
+        type: relationship.type,
+        target: relativeTarget("word/document.xml", destination),
+        xml: "",
+      };
+      relationshipsXml = replaceOrAddRelationship(
+        relationshipsXml,
+        importedRelationship,
+      );
+      outputRelationships.push(importedRelationship);
+      rewrittenHeaderFooterReferences.push(
+        replaceAttribute(referenceElement.xml, "r:id", id),
+      );
+    }
+  }
+
+  const referenceTypes = parseContentTypes(reference.contentTypesXml);
+  for (const [source, destination] of imported) {
+    const contentType = contentTypeForPart(referenceTypes, source);
+    if (contentType) {
+      contentTypesXml = addContentType(contentTypesXml, destination, contentType);
+    }
+  }
+
+  const layout =
+    mode.preservePageLayout ?? true ? presentationTags(section) : "";
+  const preserveHeaders = mode.preserveHeadersAndFooters ?? true;
+  documentXml = documentXml.replace(
+    /<w:sectPr\b[\s\S]*?<\/w:sectPr>/g,
+    (generatedSection) => {
+      let rewritten = generatedSection;
+      if (mode.preservePageLayout ?? true) {
+        rewritten = removePresentationTags(rewritten);
+      }
+      if (preserveHeaders) {
+        rewritten = rewritten.replace(
+          /<w:(?:headerReference|footerReference)\b[^>]*\/?\s*>/g,
+          "",
+        );
+      }
+      const additions = `${rewrittenHeaderFooterReferences.join("")}${layout}`;
+      return rewritten.replace(/^(<w:sectPr\b[^>]*>)/, `$1${additions}`);
+    },
+  );
+
+  return { documentXml, relationshipsXml, contentTypesXml };
+}
+
+async function importSingletonPresentationPart(
+  relationSuffix: "theme" | "fontTable",
+  outputZip: JSZip,
+  outputRelationshipsXml: string,
+  outputContentTypesXml: string,
+  reference: LoadedReferenceDocx,
+  signal?: AbortSignal,
+): Promise<{ relationshipsXml: string; contentTypesXml: string }> {
+  const referenceRelationship = parseRelationships(
+    reference.documentRelationshipsXml,
+    "word/_rels/document.xml.rels",
+  ).find((relationship) => relationship.type.endsWith(`/${relationSuffix}`));
+  if (!referenceRelationship || referenceRelationship.targetMode) {
+    return {
+      relationshipsXml: outputRelationshipsXml,
+      contentTypesXml: outputContentTypesXml,
+    };
+  }
+  const sourcePart = resolvePartTarget(
+    "word/document.xml",
+    referenceRelationship.target,
+  );
+  const imported = new Map<string, string>();
+  const destination = await importReferencePartGraph(
+    outputZip,
+    reference,
+    sourcePart,
+    imported,
+    relationSuffix === "fontTable" ? new Set(["font"]) : new Set(),
+    signal,
+  );
+
+  let relationshipsXml = outputRelationshipsXml;
+  const outputRelationships = parseRelationships(
+    relationshipsXml,
+    "word/_rels/document.xml.rels",
+  );
+  const existing = outputRelationships.find((relationship) =>
+    relationship.type.endsWith(`/${relationSuffix}`),
+  );
+  const relation: Relationship = {
+    id: existing?.id ?? nextRelationshipId(outputRelationships),
+    type: referenceRelationship.type,
+    target: relativeTarget("word/document.xml", destination),
+    xml: "",
+  };
+  relationshipsXml = replaceOrAddRelationship(relationshipsXml, relation, existing);
+
+  let contentTypesXml = addDefaultContentTypes(
+    outputContentTypesXml,
+    reference.contentTypesXml,
+  );
+  const referenceTypes = parseContentTypes(reference.contentTypesXml);
+  for (const [source, importedDestination] of imported) {
+    const contentType = contentTypeForPart(referenceTypes, source);
+    if (contentType) {
+      contentTypesXml = addContentType(
+        contentTypesXml,
+        importedDestination,
+        contentType,
+      );
+    }
+  }
+  return { relationshipsXml, contentTypesXml };
+}
+
+export async function applyReferenceDocxPresentation(
+  generatedDocx: ArrayBuffer,
+  reference: LoadedReferenceDocx,
+  mode: ReferenceDocxModeOptions = {},
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  try {
+    throwIfReferenceAborted(signal);
+    const outputZip = await JSZip.loadAsync(generatedDocx);
+    let documentXml = await readXml(outputZip, "word/document.xml");
+    const generatedStylesXml = await readXml(outputZip, "word/styles.xml");
+    const generatedNumberingXml = await readXml(outputZip, "word/numbering.xml");
+    let relationshipsXml = await readXml(
+      outputZip,
+      "word/_rels/document.xml.rels",
+    );
+    let contentTypesXml = await readXml(outputZip, "[Content_Types].xml");
+    await yieldToAbortSignal(signal);
+
+    const referenceStyles = parseStyles(reference.stylesXml);
+    const styleMap = resolveStyleMap(referenceStyles, mode);
+    const numbering = remapReferenceNumbering(
+      generatedNumberingXml,
+      reference.numberingXml,
+    );
+    const remappedReferenceStyles = rewriteStyleNumbering(
+      reference.stylesXml,
+      numbering.numIdMap,
+    );
+    const stylesXml = mergeStyles(remappedReferenceStyles, generatedStylesXml);
+    documentXml = applyStyleMapToDocument(documentXml, styleMap);
+
+    const sectionResult = await adoptSectionPresentation(
+      documentXml,
+      outputZip,
+      relationshipsXml,
+      contentTypesXml,
+      reference,
+      mode,
+      signal,
+    );
+    documentXml = sectionResult.documentXml;
+    relationshipsXml = sectionResult.relationshipsXml;
+    contentTypesXml = sectionResult.contentTypesXml;
+
+    for (const relationSuffix of ["theme", "fontTable"] as const) {
+      const imported = await importSingletonPresentationPart(
+        relationSuffix,
+        outputZip,
+        relationshipsXml,
+        contentTypesXml,
+        reference,
+        signal,
+      );
+      relationshipsXml = imported.relationshipsXml;
+      contentTypesXml = imported.contentTypesXml;
+    }
+
+    outputZip.file("word/document.xml", documentXml);
+    outputZip.file("word/styles.xml", stylesXml);
+    outputZip.file("word/numbering.xml", numbering.xml);
+    outputZip.file("word/_rels/document.xml.rels", relationshipsXml);
+    outputZip.file("[Content_Types].xml", contentTypesXml);
+
+    throwIfReferenceAborted(signal);
+    const output = await outputZip.generateAsync({
+      type: "uint8array",
+      compression: "DEFLATE",
+      compressionOptions: { level: 6 },
+    });
+    throwIfReferenceAborted(signal);
+    return output;
+  } catch (error) {
+    if (error instanceof MarkdownConversionError) throw error;
+    throw referenceError(
+      "Failed to generate DOCX from reference presentation",
+      "INVALID_PACKAGE",
+      { originalError: error },
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,108 @@ export interface MathRenderingOptions {
 
 export type ReferenceDocxInput = InputDataType;
 
+/** In-memory bytes accepted by the reference-style generation workflow. */
+export type ReferenceDocxBytes = Uint8Array | ArrayBuffer | Blob;
+
+/** Semantic Markdown roles that can adopt a named style from a reference DOCX. */
+export type ReferenceDocxStyleRole =
+  | "normal"
+  | "title"
+  | "heading1"
+  | "heading2"
+  | "heading3"
+  | "heading4"
+  | "heading5"
+  | "heading6"
+  | "blockquote"
+  | "codeBlock"
+  | "caption"
+  | "listParagraph"
+  | "table"
+  | "strong"
+  | "emphasis"
+  | "inlineCode"
+  | "hyperlink";
+
+/** Selects a reference style deterministically by its Word ID or display name. */
+export type ReferenceDocxStyleSelector =
+  | { id: string; name?: never }
+  | { name: string; id?: never };
+
+export type ReferenceDocxStyleMap = Partial<
+  Record<ReferenceDocxStyleRole, ReferenceDocxStyleSelector | null>
+>;
+
+export interface ReferenceDocxPackageLimits {
+  /** Maximum uploaded/reference ZIP size. Defaults to 16 MiB. */
+  maxCompressedBytes?: number;
+  /** Maximum sum of central-directory uncompressed sizes. Defaults to 64 MiB. */
+  maxUncompressedBytes?: number;
+  /** Maximum uncompressed size of one ZIP entry. Defaults to 16 MiB. */
+  maxEntryUncompressedBytes?: number;
+  /** Maximum ZIP entry count. Defaults to 512. */
+  maxEntries?: number;
+}
+
+export interface ReferenceDocxModeOptions {
+  /**
+   * Typed overrides for Markdown-role to Word-style mapping. Omit a role to
+   * use conventional Word IDs/names; set it to null to keep generated styling.
+   */
+  styles?: ReferenceDocxStyleMap;
+  /**
+   * Behavior when an explicit style selector cannot be resolved. Defaults to
+   * "fallback", which keeps the converter's generated style/direct formatting.
+   */
+  missingStyleBehavior?: "fallback" | "throw";
+  /**
+   * Behavior when a name selector matches multiple styles. Defaults to
+   * "throw"; "first" selects the first definition in styles.xml.
+   */
+  duplicateStyleNameBehavior?: "first" | "throw";
+  /** Copy page size, margins, orientation, and relevant final-section settings. */
+  preservePageLayout?: boolean;
+  /** Import final-section headers and footers without copying reference body text. */
+  preserveHeadersAndFooters?: boolean;
+  /** Bounded ZIP/package processing limits for the untrusted reference input. */
+  limits?: ReferenceDocxPackageLimits;
+}
+
+/**
+ * Options for generating a new DOCX whose presentation is adopted from a
+ * reference package. This is separate from placeholder patching.
+ */
+export interface ReferenceDocxGenerationOptions extends Options {
+  reference?: ReferenceDocxModeOptions;
+}
+
+export type ReferenceDocxErrorCode =
+  | "ABORTED"
+  | "INVALID_INPUT"
+  | "INVALID_ZIP"
+  | "INVALID_PACKAGE"
+  | "UNSAFE_ENTRY_PATH"
+  | "PACKAGE_LIMIT_EXCEEDED"
+  | "MISSING_PACKAGE_PART"
+  | "MALFORMED_XML"
+  | "MISSING_STYLE"
+  | "DUPLICATE_STYLE_NAME"
+  | "STYLE_TYPE_MISMATCH"
+  | "UNSUPPORTED_RELATIONSHIP";
+
+/** Actionable context exposed by reference-mode MarkdownConversionError values. */
+export interface ReferenceDocxErrorContext {
+  phase: "reference-docx";
+  code: ReferenceDocxErrorCode;
+  entry?: string;
+  role?: ReferenceDocxStyleRole;
+  selector?: ReferenceDocxStyleSelector;
+  relationshipType?: string;
+  limit?: number;
+  actual?: number;
+  originalError?: unknown;
+}
+
 export type MarkdownDocxPatch =
   | string
   | {

--- a/tests/package-consumer.mjs
+++ b/tests/package-consumer.mjs
@@ -55,10 +55,13 @@ try {
   fs.writeFileSync(
     path.join(consumerDir, "index.ts"),
     [
-      'import { convertMarkdownToDocx } from "@mohtasham/md-to-docx";',
+      'import { convertMarkdownToDocx, convertMarkdownWithReferenceDocxToBuffer, type ReferenceDocxGenerationOptions } from "@mohtasham/md-to-docx";',
       "",
       "async function main() {",
+      "  const referenceOptions: ReferenceDocxGenerationOptions = { reference: { missingStyleBehavior: \"throw\" } };",
       '  const doc = await convertMarkdownToDocx("# Hello");',
+      "  void convertMarkdownWithReferenceDocxToBuffer;",
+      "  void referenceOptions;",
       "  console.log(doc instanceof Blob);",
       "}",
       "",

--- a/tests/reference-docx-styles.test.ts
+++ b/tests/reference-docx-styles.test.ts
@@ -276,7 +276,7 @@ const answer = 42;
         "word/styles.xml",
         styles.replace(
           "</w:styles>",
-          '<w:style w:type="paragraph" w:styleId="CorpH1Duplicate"><w:name w:val="Executive Heading"/></w:style></w:styles>',
+          '<w:style w:type="paragraph" w:styleId="CorpH1Duplicate"><w:name w:val="Executive Heading"/></w:style><w:style w:type="paragraph" w:styleId="CorpQuoteDuplicate"><w:name w:val="Quote"/></w:style></w:styles>',
         ),
       );
     });
@@ -300,6 +300,13 @@ const answer = 42;
     expect(
       await xml(await JSZip.loadAsync(firstDuplicate), "word/document.xml"),
     ).toContain('w:pStyle w:val="CorpH1"');
+    const automaticDuplicate = await convertMarkdownWithReferenceDocxToBuffer(
+      "> Automatically resolved quote",
+      duplicate,
+    );
+    expect(
+      await xml(await JSZip.loadAsync(automaticDuplicate), "word/document.xml"),
+    ).toContain('w:pStyle w:val="CorpQuote"');
 
     await expect(
       convertMarkdownWithReferenceDocxToBuffer("text", Buffer.from("not a zip")),

--- a/tests/reference-docx-styles.test.ts
+++ b/tests/reference-docx-styles.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "node:fs";
+import path from "node:path";
+import JSZip from "jszip";
+import {
+  convertMarkdownToBuffer,
+  convertMarkdownWithReferenceDocx,
+  convertMarkdownWithReferenceDocxToArrayBuffer,
+  convertMarkdownWithReferenceDocxToBuffer,
+  MarkdownConversionError,
+  type ReferenceDocxErrorContext,
+} from "../src/index";
+
+const fixturePath = path.join(
+  process.cwd(),
+  "tests",
+  "fixtures",
+  "reference-template.docx",
+);
+
+const THEME_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Corporate Theme">
+  <a:themeElements><a:clrScheme name="Corporate"><a:dk1><a:srgbClr val="112233"/></a:dk1></a:clrScheme>
+  <a:fontScheme name="Corporate Fonts"><a:majorFont><a:latin typeface="Aptos Display"/></a:majorFont><a:minorFont><a:latin typeface="Aptos"/></a:minorFont></a:fontScheme>
+  <a:fmtScheme name="Corporate Format"/></a:themeElements>
+</a:theme>`;
+
+const STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:docDefaults><w:rPrDefault><w:rPr><w:rFonts w:asciiTheme="minorHAnsi"/></w:rPr></w:rPrDefault><w:pPrDefault/></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="CorpBody"><w:name w:val="Normal"/><w:rPr><w:color w:val="334455"/></w:rPr></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpTitle"><w:name w:val="Corporate Title"/><w:basedOn w:val="CorpBody"/></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpH1"><w:name w:val="Executive Heading"/><w:basedOn w:val="CorpBody"/><w:rPr><w:color w:val="AA2200"/></w:rPr></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpH2"><w:name w:val="Division Heading"/><w:basedOn w:val="CorpBody"/></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpQuote"><w:name w:val="Quote"/><w:basedOn w:val="CorpBody"/></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpCode"><w:name w:val="Code Block"/><w:basedOn w:val="CorpBody"/></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpCaption"><w:name w:val="Caption"/><w:basedOn w:val="CorpBody"/></w:style>
+  <w:style w:type="paragraph" w:styleId="CorpList"><w:name w:val="List Paragraph"/><w:basedOn w:val="CorpBody"/><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr></w:style>
+  <w:style w:type="table" w:styleId="CorpTable"><w:name w:val="Normal Table"/></w:style>
+  <w:style w:type="character" w:styleId="CorpStrong"><w:name w:val="Strong"/><w:rPr><w:b/></w:rPr></w:style>
+  <w:style w:type="character" w:styleId="CorpEmphasis"><w:name w:val="Emphasis"/><w:rPr><w:i/></w:rPr></w:style>
+  <w:style w:type="character" w:styleId="CorpInline"><w:name w:val="Inline Code"/><w:rPr><w:rFonts w:ascii="Consolas"/></w:rPr></w:style>
+  <w:style w:type="character" w:styleId="CorpLink"><w:name w:val="Hyperlink"/><w:rPr><w:color w:val="008844"/></w:rPr></w:style>
+</w:styles>`;
+
+function addRelationship(
+  xml: string,
+  id: string,
+  type: string,
+  target: string,
+): string {
+  const relationship = `<Relationship Id="${id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/${type}" Target="${target}"/>`;
+  if (xml.includes("</Relationships>")) {
+    return xml.replace(
+      "</Relationships>",
+      `${relationship}</Relationships>`,
+    );
+  }
+  return xml.replace(/<Relationships\b([^>]*)\/>/, `<Relationships$1>${relationship}</Relationships>`);
+}
+
+async function createReferenceFixture(
+  mutate?: (zip: JSZip) => void | Promise<void>,
+): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(fs.readFileSync(fixturePath));
+  zip.file("word/styles.xml", STYLES_XML);
+  zip.file("word/theme/theme1.xml", THEME_XML);
+  zip.file(
+    "word/fontTable.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:fonts xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:font w:name="Aptos"><w:family w:val="swiss"/></w:font></w:fonts>`,
+  );
+
+  const relsPath = "word/_rels/document.xml.rels";
+  let rels = await zip.file(relsPath)!.async("string");
+  if (!rels.includes("/theme\"")) {
+    rels = addRelationship(rels, "rIdTheme", "theme", "theme/theme1.xml");
+  }
+  zip.file(relsPath, rels);
+
+  const typesPath = "[Content_Types].xml";
+  let types = await zip.file(typesPath)!.async("string");
+  if (!types.includes("/word/theme/theme1.xml")) {
+    types = types.replace(
+      "</Types>",
+      `<Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>`,
+    );
+  }
+  zip.file(typesPath, types);
+
+  await mutate?.(zip);
+  return zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+}
+
+async function xml(zip: JSZip, name: string): Promise<string> {
+  const file = zip.file(name);
+  if (!file) throw new Error(`${name} not found`);
+  return file.async("string");
+}
+
+function errorContext(error: unknown): ReferenceDocxErrorContext | undefined {
+  return error instanceof MarkdownConversionError
+    ? (error.context as ReferenceDocxErrorContext)
+    : undefined;
+}
+
+describe("reference DOCX style generation", () => {
+  it("adopts named styles by name and ID without copying static body content", async () => {
+    const reference = await createReferenceFixture();
+    const output = await convertMarkdownWithReferenceDocxToBuffer(
+      `# Fresh report
+
+## Details
+
+Body with **strong**, *emphasis*, \`inline code\`, and [a link](https://example.com).
+
+> Quoted guidance.
+
+\`\`\`text
+const answer = 42;
+\`\`\`
+
+| Metric | Value |
+| --- | --- |
+| Score | 42 |
+
+1. First
+2. Second
+
+- Bullet`,
+      reference,
+      {
+        reference: {
+          styles: {
+            heading1: { name: "Executive Heading" },
+            heading2: { id: "CorpH2" },
+          },
+        },
+      },
+    );
+    const zip = await JSZip.loadAsync(output);
+    const documentXml = await xml(zip, "word/document.xml");
+    const stylesXml = await xml(zip, "word/styles.xml");
+
+    expect(documentXml).toContain("Fresh report");
+    expect(documentXml).not.toContain("Corporate Cover Page");
+    expect(documentXml).not.toContain("Static closing paragraph");
+    expect(documentXml).toContain('w:pStyle w:val="CorpH1"');
+    expect(documentXml).toContain('w:pStyle w:val="CorpH2"');
+    expect(documentXml).toContain('w:pStyle w:val="CorpBody"');
+    expect(documentXml).toContain('w:pStyle w:val="CorpQuote"');
+    expect(documentXml).toContain('w:pStyle w:val="CorpCode"');
+    expect(documentXml).toContain('w:pStyle w:val="CorpList"');
+    expect(documentXml).toContain('w:tblStyle w:val="CorpTable"');
+    expect(documentXml).toContain('w:rStyle w:val="CorpStrong"');
+    expect(documentXml).toContain('w:rStyle w:val="CorpEmphasis"');
+    expect(documentXml).toContain('w:rStyle w:val="CorpInline"');
+    expect(documentXml).toContain('w:rStyle w:val="CorpLink"');
+    expect(stylesXml).toContain('w:styleId="CorpH1"');
+    expect(stylesXml).toContain('w:styleId="FootnoteText"');
+  });
+
+  it("preserves theme, fonts, page geometry, headers, footers, and usable table width", async () => {
+    const output = await convertMarkdownWithReferenceDocxToBuffer(
+      `# New body
+
+| A | B |
+| --- | --- |
+| 1 | 2 |`,
+      await createReferenceFixture(),
+    );
+    const zip = await JSZip.loadAsync(output);
+    const documentXml = await xml(zip, "word/document.xml");
+    const relationshipsXml = await xml(zip, "word/_rels/document.xml.rels");
+    const contentTypesXml = await xml(zip, "[Content_Types].xml");
+    const themePath = Object.keys(zip.files).find((name) =>
+      name.endsWith("reference-package/word/theme/theme1.xml"),
+    );
+    const fontPath = Object.keys(zip.files).find((name) =>
+      name.endsWith("reference-package/word/fontTable.xml"),
+    );
+    const headerPath = Object.keys(zip.files).find((name) =>
+      name.endsWith("reference-package/word/header1.xml"),
+    );
+    const footerPath = Object.keys(zip.files).find((name) =>
+      name.endsWith("reference-package/word/footer1.xml"),
+    );
+
+    expect(documentXml).toContain('w:top="2000"');
+    expect(documentXml).toContain('w:left="1400"');
+    expect(documentXml).toContain('w:tblW w:type="dxa" w:w="9306"');
+    expect(documentXml).toContain("w:headerReference");
+    expect(documentXml).toContain("w:footerReference");
+    expect(relationshipsXml).toContain("reference-package/word/header1.xml");
+    expect(relationshipsXml).toContain("reference-package/word/footer1.xml");
+    expect(relationshipsXml).toContain("reference-package/word/theme/theme1.xml");
+    expect(relationshipsXml).toContain("reference-package/word/fontTable.xml");
+    expect(contentTypesXml).toContain("reference-package/word/theme/theme1.xml");
+    expect(themePath && (await xml(zip, themePath))).toContain("Corporate Theme");
+    expect(fontPath && (await xml(zip, fontPath))).toContain('w:name="Aptos"');
+    expect(headerPath && (await xml(zip, headerPath))).toContain("Template Header");
+    expect(footerPath && (await xml(zip, footerPath))).toContain("Template Footer");
+  });
+
+  it("remaps reference numbering above generated ordered and bullet list IDs", async () => {
+    const output = await convertMarkdownWithReferenceDocxToBuffer(
+      "1. Ordered\n2. Still ordered\n\n- Bullet",
+      await createReferenceFixture(),
+    );
+    const zip = await JSZip.loadAsync(output);
+    const documentXml = await xml(zip, "word/document.xml");
+    const numberingXml = await xml(zip, "word/numbering.xml");
+    const stylesXml = await xml(zip, "word/styles.xml");
+    const numIds = Array.from(
+      numberingXml.matchAll(/<w:num\b[^>]*w:numId="(\d+)"/g),
+      (match) => Number(match[1]),
+    );
+    const styleNumId = Number(
+      stylesXml
+        .match(/w:styleId="CorpList"[\s\S]*?<w:numId w:val="(\d+)"/)?.[1],
+    );
+
+    expect(new Set(numIds).size).toBe(numIds.length);
+    expect(documentXml).toMatch(/<w:numId w:val="1"\/>/);
+    expect(documentXml).toMatch(/<w:numId w:val="2"\/>/);
+    expect(styleNumId).toBeGreaterThan(2);
+    expect(numIds).toContain(styleNumId);
+  });
+
+  it("keeps generated tables, images, and links relationship-safe", async () => {
+    const png =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z7SAAAAAASUVORK5CYII=";
+    const output = await convertMarkdownWithReferenceDocxToBuffer(
+      `| A | B |
+| --- | --- |
+| 1 | 2 |
+
+![pixel](data:image/png;base64,${png})
+
+[OpenAI](https://openai.com)`,
+      await createReferenceFixture(),
+    );
+    const zip = await JSZip.loadAsync(output);
+    const documentXml = await xml(zip, "word/document.xml");
+    const relationshipsXml = await xml(zip, "word/_rels/document.xml.rels");
+
+    expect(documentXml).toContain("<w:tbl>");
+    expect(documentXml).toContain("<w:drawing>");
+    expect(documentXml).toContain("<w:hyperlink");
+    expect(relationshipsXml).toContain('Target="https://openai.com"');
+    expect(Object.keys(zip.files).some((name) => name.startsWith("word/media/"))).toBe(true);
+  });
+
+  it("defines fallback, throw, duplicate-name, malformed-package, and abort behavior", async () => {
+    const reference = await createReferenceFixture();
+    const fallback = await convertMarkdownWithReferenceDocxToBuffer("# Heading", reference, {
+      reference: { styles: { heading1: { name: "Missing Heading" } } },
+    });
+    expect(await xml(await JSZip.loadAsync(fallback), "word/document.xml")).toContain(
+      'w:pStyle w:val="Heading1"',
+    );
+
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("# Heading", reference, {
+        reference: {
+          missingStyleBehavior: "throw",
+          styles: { heading1: { name: "Missing Heading" } },
+        },
+      }),
+    ).rejects.toMatchObject({
+      context: { phase: "reference-docx", code: "MISSING_STYLE", role: "heading1" },
+    });
+
+    const duplicate = await createReferenceFixture(async (zip) => {
+      const styles = await xml(zip, "word/styles.xml");
+      zip.file(
+        "word/styles.xml",
+        styles.replace(
+          "</w:styles>",
+          '<w:style w:type="paragraph" w:styleId="CorpH1Duplicate"><w:name w:val="Executive Heading"/></w:style></w:styles>',
+        ),
+      );
+    });
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("# Heading", duplicate, {
+        reference: { styles: { heading1: { name: "Executive Heading" } } },
+      }),
+    ).rejects.toMatchObject({
+      context: { code: "DUPLICATE_STYLE_NAME" },
+    });
+    const firstDuplicate = await convertMarkdownWithReferenceDocxToBuffer(
+      "# Heading",
+      duplicate,
+      {
+        reference: {
+          duplicateStyleNameBehavior: "first",
+          styles: { heading1: { name: "Executive Heading" } },
+        },
+      },
+    );
+    expect(
+      await xml(await JSZip.loadAsync(firstDuplicate), "word/document.xml"),
+    ).toContain('w:pStyle w:val="CorpH1"');
+
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("text", Buffer.from("not a zip")),
+    ).rejects.toMatchObject({ context: { code: "INVALID_ZIP" } });
+
+    const nonDocx = new JSZip();
+    nonDocx.file("hello.txt", "hello");
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer(
+        "text",
+        await nonDocx.generateAsync({ type: "nodebuffer" }),
+      ),
+    ).rejects.toMatchObject({ context: { code: "MISSING_PACKAGE_PART" } });
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("text", reference, {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ context: { code: "ABORTED" } });
+  });
+
+  it("rejects unsafe ZIP paths and bounded zip-bomb-style packages", async () => {
+    const unsafe = new JSZip();
+    unsafe.file("../word/document.xml", "unsafe");
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer(
+        "text",
+        await unsafe.generateAsync({ type: "nodebuffer" }),
+      ),
+    ).rejects.toMatchObject({ context: { code: "UNSAFE_ENTRY_PATH" } });
+
+    const reference = await createReferenceFixture();
+    let caught: unknown;
+    try {
+      await convertMarkdownWithReferenceDocxToBuffer("text", reference, {
+        reference: { limits: { maxUncompressedBytes: 1024 } },
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(MarkdownConversionError);
+    expect(errorContext(caught)).toMatchObject({
+      code: "PACKAGE_LIMIT_EXCEEDED",
+      limit: 1024,
+    });
+
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("text", reference, {
+        reference: { limits: { maxEntries: 3 } },
+      }),
+    ).rejects.toMatchObject({ context: { code: "PACKAGE_LIMIT_EXCEEDED" } });
+  });
+
+  it("rejects unsupported active header/footer relationship constructs", async () => {
+    const reference = await createReferenceFixture(async (zip) => {
+      const relsPath = "word/_rels/header1.xml.rels";
+      const rels = await xml(zip, relsPath);
+      zip.file(
+        relsPath,
+        addRelationship(rels, "rIdChart", "chart", "charts/chart1.xml"),
+      );
+    });
+
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("Fresh body", reference),
+    ).rejects.toMatchObject({
+      context: {
+        code: "UNSUPPORTED_RELATIONSHIP",
+        relationshipType:
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",
+      },
+    });
+  });
+
+  it("returns Blob, ArrayBuffer, and Buffer and keeps ordinary conversion isolated", async () => {
+    const reference = await createReferenceFixture();
+    const [blob, arrayBuffer, buffer] = await Promise.all([
+      convertMarkdownWithReferenceDocx("# Output", reference),
+      convertMarkdownWithReferenceDocxToArrayBuffer("# Output", reference),
+      convertMarkdownWithReferenceDocxToBuffer("# Output", reference),
+    ]);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(arrayBuffer).toBeInstanceOf(ArrayBuffer);
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+
+    const ordinary = await convertMarkdownToBuffer("# Ordinary");
+    const ordinaryZip = await JSZip.loadAsync(ordinary);
+    expect(Object.keys(ordinaryZip.files).some((name) => name.includes("reference-package"))).toBe(
+      false,
+    );
+    expect(await xml(ordinaryZip, "word/document.xml")).toContain(
+      'w:pStyle w:val="Heading1"',
+    );
+  });
+
+  it("produces deterministic Word XML for the same markdown and reference", async () => {
+    const reference = await createReferenceFixture();
+    const first = await JSZip.loadAsync(
+      await convertMarkdownWithReferenceDocxToBuffer("# Stable\n\n1. One", reference),
+    );
+    const second = await JSZip.loadAsync(
+      await convertMarkdownWithReferenceDocxToBuffer("# Stable\n\n1. One", reference),
+    );
+    for (const part of [
+      "word/document.xml",
+      "word/styles.xml",
+      "word/numbering.xml",
+      "word/_rels/document.xml.rels",
+    ]) {
+      expect(await xml(first, part)).toBe(await xml(second, part));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds v3 roadmap item 3: a true reference-DOCX style workflow that generates a brand-new Markdown-owned document while adopting presentation from an existing Word reference.

The new helpers are:

- `convertMarkdownWithReferenceDocx(...): Promise<Blob>`
- `convertMarkdownWithReferenceDocxToArrayBuffer(...): Promise<ArrayBuffer>`
- `convertMarkdownWithReferenceDocxToBuffer(...): Promise<Buffer>`

This is intentionally separate from `patchMarkdownInDocx*`: patching preserves an existing body and replaces placeholders, while reference-style generation excludes the reference body and creates fresh content from the supplied Markdown.

## Complete usage example

```ts
import {
  convertMarkdownWithReferenceDocxToBuffer,
} from "@mohtasham/md-to-docx";
import fs from "node:fs/promises";

const reference = await fs.readFile("corporate-reference.docx");
const markdown = `# Quarterly Update

Revenue increased **18%**.

1. Confirm the forecast
2. Publish the board pack`;

const output = await convertMarkdownWithReferenceDocxToBuffer(
  markdown,
  reference,
  {
    reference: {
      styles: {
        normal: { name: "Corporate Body" },
        heading1: { id: "CorpHeading1" },
        blockquote: { name: "Executive Quote" },
        codeBlock: { name: "Code Block" },
        table: { name: "Corporate Table" },
      },
      missingStyleBehavior: "throw",
      duplicateStyleNameBehavior: "throw",
      preservePageLayout: true,
      preserveHeadersAndFooters: true,
    },
  },
);

await fs.writeFile("quarterly-update.docx", output);
```

## Package behavior

Copied or derived:

- Reference `styles.xml` document defaults plus named paragraph, character, and table styles; converter-required missing styles are appended.
- Theme and font-table relationship parts, including bounded embedded-font dependencies.
- Reference numbering definitions, remapped above generated abstract/instance IDs so ordered and unordered Markdown lists cannot collide.
- Final-reference-section page geometry, margins, orientation, columns/grid, page-number settings, and table content width.
- Final-section headers/footers and their internal image dependencies, using fresh document relationship IDs and merged content types.
- External header/footer hyperlinks are preserved as relationships but are never fetched.

Deliberate exclusions:

- Static reference body content, cover pages, closing text, comments, reference footnotes, custom properties, document settings, macros, embedded objects, unused media, and unsupported header/footer constructs.
- Only final-section presentation is adopted; reference body section sequencing is not replayed.
- Header/footer internal relationships other than images fail explicitly rather than creating active or broken content.

## Security and compatibility

Reference bytes are treated as an untrusted ZIP package. The implementation rejects unsafe entry paths, malformed/non-DOCX packages, DTD/entity declarations, oversized compressed/uncompressed inputs, oversized entries, excessive entry counts, missing parts, ambiguous styles, and unsupported relationships. Defaults are 16 MiB compressed, 64 MiB total uncompressed, 16 MiB per entry, and 512 entries. `AbortSignal` is honored, no external relationship is fetched, and failures use `MarkdownConversionError` with typed `ReferenceDocxErrorContext`.

The Blob and ArrayBuffer helpers support modern in-memory browser runtimes; Buffer output and reference-package usage are Node-first. Ordinary `convertMarkdownToDocx*` code is unchanged when reference mode is unused. The CLI remains ordinary conversion only because binary reference input is not represented by JSON options.

This branch starts from `feature/v3` and does not depend on or modify draft PRs #80 or #81.

## Validation

- `npm run lint` — passed
- `npm run build` — passed
- `npm test -- --runInBand` — passed, 11 suites / 182 tests
- `npm run test:consumer` — passed for Node16, NodeNext, and bundler resolution
- Generated a real reference-style DOCX, passed `unzip -t`, validated `word/document.xml` with `xmllint`, opened it headlessly in LibreOffice, exported it to a one-page A4 PDF, and visually inspected the preserved header/footer, fresh body, adopted heading, table, quote, ordered list, and hyperlink.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new OOXML merge surface and untrusted-ZIP handling affect output packages and security posture, though failures are explicit and ordinary conversion is isolated when reference mode is unused.
> 
> **Overview**
> Adds a **reference-DOCX style generation** path distinct from placeholder patching: Markdown becomes the full body while an existing `.docx` supplies presentation only (no static reference body text).
> 
> New public APIs `convertMarkdownWithReferenceDocx`, `ToArrayBuffer`, and `ToBuffer` generate a normal Markdown DOCX, then merge in reference `styles.xml` (with role-based ID/name selectors), theme/font parts, remapped numbering, final-section page layout, and headers/footers. **`jszip` moves to a runtime dependency** to support package inspection and merging in `referenceDocx.ts`.
> 
> Reference inputs are treated as **untrusted ZIPs** with configurable size/entry limits, safe-path checks, `AbortSignal` support, and typed `ReferenceDocxErrorContext` codes. Docs, changelog, agent skill, consumer test exports, and a broad Jest suite document and lock in the behavior; ordinary `convertMarkdownToDocx*` is unchanged when this mode is not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 333eff0e253f0e55588528a33bdbaeb9c9b78e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->