### PR TITLE
fix: resolve v3 release blockers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -2475,9 +2475,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2892,9 +2892,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3427,9 +3427,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -5782,9 +5782,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7312,9 +7312,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7393,8 +7393,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -7418,11 +7418,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.11",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -7438,7 +7438,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -7447,11 +7447,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -7523,7 +7523,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7571,7 +7571,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7916,7 +7916,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8290,12 +8290,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -8309,13 +8309,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -8332,12 +8332,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8357,12 +8357,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -8731,13 +8731,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8942,7 +8942,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9067,7 +9067,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -9163,7 +9163,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/src/documentStyles.ts
+++ b/src/documentStyles.ts
@@ -1,4 +1,4 @@
-import { AlignmentType, IParagraphStyleOptions } from "docx";
+import { AlignmentType, IStylesOptions } from "docx";
 import { Style } from "./types.js";
 import { resolveFontFamily } from "./utils/styleUtils.js";
 import { runLanguage } from "./accessibility.js";
@@ -20,14 +20,16 @@ function headingRunSize(level: number, style: Style): number {
 }
 
 /**
- * Builds the paragraph style definitions (Title, Heading1-6, Strong) shared
- * by every generated document. Heading styles only differ by font size and
- * spacing, so they are generated from a small table.
+ * Customizes docx's built-in style definitions instead of appending a second
+ * style with the same ID. Duplicate style IDs are invalid WordprocessingML
+ * and also make generated documents unsafe to reuse as reference DOCX input.
  */
-export function buildParagraphStyles(style: Style): IParagraphStyleOptions[] {
+export function buildDefaultStyles(
+  style: Style,
+): NonNullable<IStylesOptions["default"]> {
   const font = resolveFontFamily(style);
 
-  const headingStyles: IParagraphStyleOptions[] = HEADING_SPACING.map(
+  const headingStyles = HEADING_SPACING.map(
     (spacing, index) => {
       const level = index + 1;
       return {
@@ -52,13 +54,18 @@ export function buildParagraphStyles(style: Style): IParagraphStyleOptions[] {
     }
   );
 
-  return [
-    {
-      id: "Title",
-      name: "Title",
-      basedOn: "Normal",
-      next: "Normal",
-      quickFormat: true,
+  return {
+    ...(style.language || style.direction === "RTL"
+      ? {
+          document: {
+            run: {
+              ...(style.language ? { language: runLanguage(style) } : {}),
+              ...(style.direction === "RTL" ? { rightToLeft: true } : {}),
+            },
+          },
+        }
+      : {}),
+    title: {
       run: {
         size: style.titleSize,
         bold: true,
@@ -75,10 +82,10 @@ export function buildParagraphStyles(style: Style): IParagraphStyleOptions[] {
         alignment: AlignmentType.CENTER,
       },
     },
-    ...headingStyles,
-    {
-      id: "Strong",
-      name: "Strong",
+    ...Object.fromEntries(
+      headingStyles.map((heading, index) => [`heading${index + 1}`, heading]),
+    ),
+    strong: {
       run: {
         bold: true,
         font,
@@ -86,5 +93,5 @@ export function buildParagraphStyles(style: Style): IParagraphStyleOptions[] {
         ...(style.direction === "RTL" ? { rightToLeft: true } : {}),
       },
     },
-  ];
+  };
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,7 +19,12 @@ export interface MarkdownConversionErrorContext {
  * @param context - The context of the error
  */
 export class MarkdownConversionError extends Error {
-  constructor(message: string, public context?: MarkdownConversionErrorContext) {
+  /**
+   * Kept as `unknown` for source compatibility with v2 consumers that attach
+   * their own primitive, array, or object context values. Core errors use the
+   * exported {@link MarkdownConversionErrorContext} shape internally.
+   */
+  constructor(message: string, public context?: unknown) {
     super(message);
     this.name = "MarkdownConversionError";
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import {
   replaceTocPlaceholders,
   TocHeadingEntry,
 } from "./tocBuilder.js";
-import { buildParagraphStyles } from "./documentStyles.js";
+import { buildDefaultStyles } from "./documentStyles.js";
 import {
   enforceElementLimit,
   enforceInputLength,
@@ -65,7 +65,7 @@ import {
   normalizeDocumentMetadata,
   validateDocumentMetadata,
 } from "./metadata.js";
-import { runLanguage, validateAccessibilityOptions } from "./accessibility.js";
+import { validateAccessibilityOptions } from "./accessibility.js";
 
 const defaultStyle: Style = {
   titleSize: 32,
@@ -388,10 +388,6 @@ export async function parseToDocxOptions(
     };
 
     const resolvedSections = resolveSections(markdown, options, style);
-    const crossReferences = await prepareCrossReferenceRegistry(
-      resolvedSections.map((section) => section.markdown),
-      options,
-    );
     const renderedSections: {
       children: (Paragraph | Table)[];
       style: Style;
@@ -410,6 +406,24 @@ export async function parseToDocxOptions(
       options,
       sectionCount: resolvedSections.length,
     });
+    const preparedAsts: Root[] = [];
+    for (const [sectionIndex, section] of resolvedSections.entries()) {
+      preparedAsts.push(
+        await prepareMarkdownAst(section.markdown, section.style, options, {
+          pluginRuntime,
+          pluginSection: {
+            index: sectionIndex,
+            count: resolvedSections.length,
+            kind: "section",
+            contentWidthTwips: getSectionContentWidthTwips(section.config),
+          },
+        }),
+      );
+    }
+    const crossReferences = buildCrossReferenceRegistry(
+      preparedAsts,
+      options.captions,
+    );
 
     for (const [sectionIndex, section] of resolvedSections.entries()) {
       throwIfAborted(options.signal);
@@ -427,6 +441,7 @@ export async function parseToDocxOptions(
           tocPlaceholders,
           tableWidthTwips: getSectionContentWidthTwips(section.config),
           footnoteIdOffset: maxFootnoteId,
+          preparedAst: preparedAsts[sectionIndex],
           crossReferences,
           pluginRuntime,
           pluginSection: {
@@ -510,21 +525,7 @@ export async function parseToDocxOptions(
       sections: docSections,
       ...(Object.keys(footnotes).length > 0 ? { footnotes } : {}),
       styles: {
-        ...(style.language || style.direction === "RTL"
-          ? {
-              default: {
-                document: {
-                  run: {
-                    ...(style.language
-                      ? { language: runLanguage(style) }
-                      : {}),
-                    ...(style.direction === "RTL" ? { rightToLeft: true } : {}),
-                  },
-                },
-              },
-            }
-          : {}),
-        paragraphStyles: buildParagraphStyles(style),
+        default: buildDefaultStyles(style),
       },
       ...(crossReferences &&
       crossReferences.definitions.size > 0 &&
@@ -803,30 +804,12 @@ async function renderMarkdownContent(
     validateModel?: (model: DocxDocumentModel) => void;
     validateAst?: (ast: Root) => void;
     crossReferences?: CrossReferenceRegistry;
+    preparedAst?: Root;
   } = {}
 ): Promise<{ content: RenderedMarkdownContent; elementCount: number }> {
-  let ast = await parseMarkdownToAst(
-    markdown,
-    options.mathRendering?.enabled !== false,
-  );
-  await yieldToAbortSignal(options.signal);
-
-  if (options.textReplacements && options.textReplacements.length > 0) {
-    applyTextReplacements(
-      ast,
-      options.textReplacements,
-      options.textReplacementMode,
-    );
-  }
-
-  if (renderOptions.pluginRuntime && renderOptions.pluginSection) {
-    ast = await renderOptions.pluginRuntime.transformAst(
-      ast,
-      style,
-      renderOptions.pluginSection,
-      options.signal,
-    );
-  }
+  const ast =
+    renderOptions.preparedAst ??
+    (await prepareMarkdownAst(markdown, style, options, renderOptions));
 
   renderOptions.validateAst?.(ast);
 
@@ -866,38 +849,37 @@ async function renderMarkdownContent(
   return { content, elementCount: pluginElementCounter.count };
 }
 
-async function prepareCrossReferenceRegistry(
-  markdownSections: string[],
+async function prepareMarkdownAst(
+  markdown: string,
+  style: Style,
   options: Options,
-): Promise<CrossReferenceRegistry | undefined> {
-  const mayContainSyntax =
-    options.textReplacements !== undefined ||
-    markdownSections.some((section) =>
-      /(?:\{#(?:fig|tbl):|\[@(?:fig|tbl):)/.test(section),
+  renderOptions: {
+    pluginRuntime?: PluginRuntime;
+    pluginSection?: PluginSectionContext;
+  } = {},
+): Promise<Root> {
+  throwIfAborted(options.signal);
+  let ast = await parseMarkdownToAst(
+    markdown,
+    options.mathRendering?.enabled !== false,
+  );
+  await yieldToAbortSignal(options.signal);
+  if (options.textReplacements && options.textReplacements.length > 0) {
+    applyTextReplacements(
+      ast,
+      options.textReplacements,
+      options.textReplacementMode,
     );
-  if (!mayContainSyntax) {
-    return undefined;
   }
-
-  const roots: Root[] = [];
-  for (const markdown of markdownSections) {
-    throwIfAborted(options.signal);
-    const ast = await parseMarkdownToAst(
-      markdown,
-      options.mathRendering?.enabled !== false,
+  if (renderOptions.pluginRuntime && renderOptions.pluginSection) {
+    ast = await renderOptions.pluginRuntime.transformAst(
+      ast,
+      style,
+      renderOptions.pluginSection,
+      options.signal,
     );
-    if (options.textReplacements && options.textReplacements.length > 0) {
-      applyTextReplacements(
-        ast,
-        options.textReplacements,
-        options.textReplacementMode,
-      );
-    }
-    roots.push(ast);
-    await yieldToAbortSignal(options.signal);
   }
-
-  return buildCrossReferenceRegistry(roots, options.captions);
+  return ast;
 }
 
 function assertPatchCompatibleAst(ast: Root, placeholder: string): void {

--- a/src/modelToDocx.ts
+++ b/src/modelToDocx.ts
@@ -982,6 +982,10 @@ export async function modelToDocx(
       return renderMermaidNode(node, context, listMarker);
     }
 
+    if (node.type === "pluginBlock") {
+      return renderPluginNode(node, listLevel, context, listMarker);
+    }
+
     if (listMarker?.taskChecked !== undefined) {
       return [
         listParagraphFromInlineNodes(
@@ -994,10 +998,6 @@ export async function modelToDocx(
         ),
         ...(await renderBlockNode(node, listLevel, context)),
       ];
-    }
-
-    if (node.type === "pluginBlock") {
-      return renderPluginNode(node, listLevel, context, listMarker);
     }
 
     if (listMarker) {
@@ -1021,10 +1021,12 @@ export async function modelToDocx(
   function imageCouldNotLoadParagraph(
     alt: string,
     paragraphOptions: Partial<IParagraphOptions> = {},
+    prefixChildren: readonly ParagraphChild[] = [],
   ): Paragraph {
     return new Paragraph({
       ...paragraphOptions,
       children: [
+        ...prefixChildren,
         new TextRun({
           text: `[Image could not be loaded: ${alt}]`,
           italics: true,
@@ -1312,6 +1314,46 @@ export async function modelToDocx(
     });
   }
 
+  function pluginInlineElementCount(
+    content: PluginInlineContent | readonly PluginInlineContent[],
+  ): number {
+    return pluginInlineNodes(content).length;
+  }
+
+  function pluginResultElementCount(result: PluginBlockResult): number {
+    if (!result || typeof result !== "object" || typeof result.type !== "string") {
+      throw new Error("Plugin returned an invalid block result");
+    }
+    switch (result.type) {
+      case "skip":
+      case "children":
+        return 0;
+      case "image":
+      case "codeBlock":
+        return 1;
+      case "paragraph":
+      case "heading":
+        return 1 + pluginInlineElementCount(result.children);
+      case "table": {
+        let count = 2;
+        for (const cell of result.headers) {
+          count += 1 + pluginInlineElementCount(cell);
+        }
+        for (const row of result.rows) {
+          count++;
+          for (const cell of row) {
+            count += 1 + pluginInlineElementCount(cell);
+          }
+        }
+        return count;
+      }
+      default:
+        throw new Error(
+          `Unsupported plugin result type: ${(result as { type: string }).type}`,
+        );
+    }
+  }
+
   function pluginFallback(
     node: Extract<DocxBlockNode, { type: "pluginBlock" }>,
     listLevel: number,
@@ -1414,12 +1456,20 @@ export async function modelToDocx(
       return renderPluginChildren(node, listLevel, context, listMarker);
     }
     if (result.type === "image") {
+      const altText = result.alt ?? "";
+      validateImageText(altText, undefined, "Plugin image");
+      assertImageAltPolicy(
+        altText,
+        options.accessibility,
+        `plugin "${node.handler.pluginName}" image`,
+      );
       const paragraphOptions = imageParagraphOptions(context, listMarker);
       if (processedImageCounter.count >= imageHandling.maxImages) {
         return [
           imageCouldNotLoadParagraph(
             result.alt || "plugin image limit reached",
             paragraphOptions,
+            taskMarkerChildren(listMarker),
           ),
         ];
       }
@@ -1434,6 +1484,7 @@ export async function modelToDocx(
           maxImageBytes: imageHandling.maxImageBytes,
           paragraphOptions,
           signal: options.signal,
+          prefixChildren: taskMarkerChildren(listMarker),
         },
         style,
       );
@@ -1455,6 +1506,7 @@ export async function modelToDocx(
                 listMarker.level,
                 listMarker.sequenceId,
                 context,
+                listMarker.taskChecked,
               )
             : listContinuationParagraphFromInlineNodes(
                 inlineNodes,
@@ -1583,9 +1635,10 @@ export async function modelToDocx(
         throw new Error("Plugin renderer returned no result");
       }
       const blocks = Array.isArray(result) ? result : [result];
-      const additionalElements = blocks.filter(
-        (block) => block.type !== "children" && block.type !== "skip",
-      ).length;
+      const additionalElements = blocks.reduce(
+        (count, block) => count + pluginResultElementCount(block),
+        0,
+      );
       if (renderOptions.pluginElementCounter) {
         renderOptions.pluginElementCounter.count += additionalElements;
         if (
@@ -1628,6 +1681,13 @@ export async function modelToDocx(
       if (
         error instanceof MarkdownConversionError &&
         error.message === "Markdown element count exceeds maxElements"
+      ) {
+        throw error;
+      }
+      if (
+        error instanceof MarkdownConversionError &&
+        (error.context as { missingImageAltText?: unknown } | undefined)
+          ?.missingImageAltText === "throw"
       ) {
         throw error;
       }

--- a/src/referenceDocx.ts
+++ b/src/referenceDocx.ts
@@ -1,4 +1,5 @@
 import JSZip from "jszip";
+import { DOMParser } from "@xmldom/xmldom";
 import { MarkdownConversionError } from "./errors.js";
 import { yieldToAbortSignal } from "./processingLimits.js";
 import type {
@@ -229,6 +230,25 @@ function assertSafeXml(xml: string, entry: string): void {
       `Reference DOCX XML part ${entry} contains a prohibited DTD or entity declaration`,
       "MALFORMED_XML",
       { entry },
+    );
+  }
+  try {
+    const document = new DOMParser({
+      onError(level, message) {
+        if (level !== "warning") throw new Error(message);
+      },
+    }).parseFromString(xml, "application/xml");
+    if (
+      !document.documentElement ||
+      document.getElementsByTagName("parsererror").length > 0
+    ) {
+      throw new Error("XML parser did not produce a well-formed document");
+    }
+  } catch (error) {
+    throw referenceError(
+      `Reference DOCX XML part ${entry} is malformed`,
+      "MALFORMED_XML",
+      { entry, originalError: error },
     );
   }
 }

--- a/tests/captions-cross-references.test.ts
+++ b/tests/captions-cross-references.test.ts
@@ -67,7 +67,9 @@ describe("figure/table captions and cross-references", () => {
 
   it("can suppress Word's automatic field-update prompt", async () => {
     const blob = await convertMarkdownToDocx(
-      `![Prompt-free figure](${ONE_PX_PNG})
+      `See [@fig:prompt-free].
+
+![Prompt-free figure](${ONE_PX_PNG})
 
 : Prompt-free caption {#fig:prompt-free}`,
       { captions: { updateFieldsOnOpen: false } },
@@ -77,6 +79,9 @@ describe("figure/table captions and cross-references", () => {
       ?.async("string");
 
     expect(settings).not.toContain("<w:updateFields");
+    const xml = await getDocumentXml(blob);
+    expect(fieldInstructions(xml, "REF")).toHaveLength(1);
+    expect(xml).toContain("Figure 1");
   });
 
   it("validates the automatic field-update option", async () => {

--- a/tests/package-consumer.mjs
+++ b/tests/package-consumer.mjs
@@ -55,7 +55,7 @@ try {
   fs.writeFileSync(
     path.join(consumerDir, "index.ts"),
     [
-      'import { convertMarkdownToDocx, convertMarkdownWithReferenceDocxToBuffer, type ReferenceDocxGenerationOptions, type MarkdownDocxPlugin, type PluginRenderContext, type AccessibilityOptions, type DocumentMetadata, type Options } from "@mohtasham/md-to-docx";',
+      'import { convertMarkdownToDocx, convertMarkdownWithReferenceDocxToBuffer, MarkdownConversionError, type ReferenceDocxGenerationOptions, type MarkdownDocxPlugin, type PluginRenderContext, type AccessibilityOptions, type DocumentMetadata, type Options } from "@mohtasham/md-to-docx";',
       "",
       "const plugin: MarkdownDocxPlugin = {",
       "  apiVersion: 1,",
@@ -69,6 +69,7 @@ try {
       "};",
       "",
       "async function main() {",
+      '  const legacyError = new MarkdownConversionError("legacy", ["custom", 42]);',
       '  const metadata: DocumentMetadata = { title: "Accessible report", language: "en-GB" };',
       '  const accessibility: AccessibilityOptions = { missingImageAltText: "throw" };',
       "  const options: Options = { metadata, accessibility, plugins: [plugin] };",
@@ -76,6 +77,7 @@ try {
       '  const doc = await convertMarkdownToDocx("# Hello", options);',
       "  void convertMarkdownWithReferenceDocxToBuffer;",
       "  void referenceOptions;",
+      "  void legacyError;",
       "  console.log(doc instanceof Blob);",
       "}",
       "",

--- a/tests/plugin-api.test.ts
+++ b/tests/plugin-api.test.ts
@@ -115,6 +115,101 @@ describe("stable custom renderer plugin API", () => {
     expect(xml.match(/<w:numPr>/g)?.length).toBe(1);
   });
 
+  it("keeps task-list numbering, checkbox, and plugin content together", async () => {
+    const plugin: MarkdownDocxPlugin = {
+      apiVersion: 1,
+      name: "acme.task",
+      transformAst(root) {
+        const list = root.children[0] as Parent;
+        const item = list.children[0] as Parent;
+        const paragraph = item.children[0] as Parent;
+        paragraph.type = "taskDirective";
+      },
+      blockNodes: [
+        {
+          nodeTypes: ["taskDirective"],
+          render: () => ({
+            type: "paragraph",
+            children: "plugin task body",
+          }),
+        },
+      ],
+    };
+    const xml = await getDocumentXml(
+      await convertMarkdownToDocx(
+        "- [ ] replace me",
+        { plugins: [plugin] },
+      ),
+    );
+    const taskParagraph = xml.match(
+      /<w:p\b(?:(?!<\/w:p>)[\s\S])*?plugin task body(?:(?!<\/w:p>)[\s\S])*?<\/w:p>/,
+    )?.[0];
+
+    expect(taskParagraph).toContain("<w:numPr>");
+    expect(taskParagraph).toContain("☐ ");
+    expect(xml.match(/<w:numPr>/g)).toHaveLength(1);
+  });
+
+  it("discovers captions and references from the rendered post-transform AST", async () => {
+    const plugin: MarkdownDocxPlugin = {
+      apiVersion: 1,
+      name: "acme.caption-order",
+      transformAst(root) {
+        const firstPair = root.children.splice(1, 2);
+        const secondPair = root.children.splice(1, 2);
+        root.children.splice(1, 0, ...secondPair, ...firstPair);
+        root.children.push(
+          {
+            type: "paragraph",
+            children: [{ type: "text", value: "See [@tbl:added]." }],
+          },
+          {
+            type: "table",
+            align: [null],
+            children: [
+              {
+                type: "tableRow",
+                children: [
+                  {
+                    type: "tableCell",
+                    children: [{ type: "text", value: "Added" }],
+                  },
+                ],
+              },
+            ],
+          } as unknown as Root["children"][number],
+          {
+            type: "paragraph",
+            children: [{ type: "text", value: ": Added table {#tbl:added}" }],
+          },
+        );
+      },
+    };
+    const xml = await getDocumentXml(
+      await convertMarkdownToDocx(
+        `See [@fig:second], then [@fig:first].
+
+![First](data:image/png;base64,${ONE_PX_PNG_BYTES.toString("base64")})
+
+: First {#fig:first}
+
+![Second](data:image/png;base64,${ONE_PX_PNG_BYTES.toString("base64")})
+
+: Second {#fig:second}`,
+        {
+          plugins: [plugin],
+          captions: { failureMode: "throw" },
+          imageHandling: { dataUrls: { enabled: true } },
+        },
+      ),
+    );
+
+    expect(xml).toMatch(/REF[^>]*>(?:(?!<\/w:fldSimple>)[\s\S])*?Figure 1/);
+    expect(xml).toContain("Figure 2");
+    expect(xml).toContain("Table 1");
+    expect(xml).toContain("Added table");
+  });
+
   it("reports blockquote/callout and footnote nesting without dropping output", async () => {
     const parents: string[] = [];
     const plugin = fencePlugin("acme.contexts", (value, context) => {
@@ -336,6 +431,29 @@ Footnote reference[^plugin].
     await expect(
       convertMarkdownToDocx("```notice\nbase\n```", {
         plugins: [
+          fencePlugin("acme.inline-output-limit", () => ({
+            type: "paragraph",
+            children: Array.from({ length: 100 }, (_, index) => `item-${index}`),
+          })),
+        ],
+        maxElements: 3,
+      }),
+    ).rejects.toThrow("Markdown element count exceeds maxElements");
+    await expect(
+      convertMarkdownToDocx("```notice\nbase\n```", {
+        plugins: [
+          fencePlugin("acme.table-output-limit", () => ({
+            type: "table",
+            headers: [["Header"]],
+            rows: Array.from({ length: 20 }, () => [["Cell"]]),
+          })),
+        ],
+        maxElements: 10,
+      }),
+    ).rejects.toThrow("Markdown element count exceeds maxElements");
+    await expect(
+      convertMarkdownToDocx("```notice\nbase\n```", {
+        plugins: [
           fencePlugin("acme.output-limit", () => [
             { type: "paragraph", children: "one" },
             { type: "paragraph", children: "two" },
@@ -360,6 +478,22 @@ Footnote reference[^plugin].
     const media = Object.keys(zip.files).filter((path) => path.startsWith("word/media/") && !path.endsWith("/"));
     expect(media).toHaveLength(1);
     expect(xml).toContain("Image could not be loaded");
+  });
+
+  it("enforces strict missing-alt policy for plugin images", async () => {
+    await expect(
+      convertMarkdownToDocx("```notice\nimage\n```", {
+        plugins: [
+          fencePlugin("acme.strict-image", () => ({
+            type: "image",
+            data: ONE_PX_PNG_BYTES,
+            contentType: "image/png",
+            alt: "   ",
+          })),
+        ],
+        accessibility: { missingImageAltText: "throw" },
+      }),
+    ).rejects.toThrow("strict accessibility mode requires a non-empty description");
   });
 
   it("shares plugin state across sections but isolates separate conversions", async () => {

--- a/tests/reference-docx-styles.test.ts
+++ b/tests/reference-docx-styles.test.ts
@@ -362,6 +362,51 @@ const answer = 42;
     ).rejects.toMatchObject({ context: { code: "PACKAGE_LIMIT_EXCEEDED" } });
   });
 
+  it("rejects malformed required and recursively imported XML parts", async () => {
+    const malformedStyles = await createReferenceFixture((zip) => {
+      zip.file(
+        "word/styles.xml",
+        STYLES_XML.replace("</w:styles>", "<w:style></w:styles>"),
+      );
+    });
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("text", malformedStyles),
+    ).rejects.toMatchObject({
+      context: { code: "MALFORMED_XML", entry: "word/styles.xml" },
+    });
+
+    const malformedHeader = await createReferenceFixture((zip) => {
+      zip.file(
+        "word/header1.xml",
+        '<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p></w:hdr>',
+      );
+    });
+    await expect(
+      convertMarkdownWithReferenceDocxToBuffer("text", malformedHeader),
+    ).rejects.toMatchObject({
+      context: { code: "MALFORMED_XML", entry: "word/header1.xml" },
+    });
+  });
+
+  it("reuses generated DOCX files as deterministic reference input", async () => {
+    const generated = await convertMarkdownToBuffer("# Generated reference");
+    const generatedZip = await JSZip.loadAsync(generated);
+    const generatedStyles = await xml(generatedZip, "word/styles.xml");
+    const styleIds = Array.from(
+      generatedStyles.matchAll(/<w:style\b[^>]*w:styleId="([^"]+)"/g),
+      (match) => match[1],
+    );
+
+    expect(new Set(styleIds).size).toBe(styleIds.length);
+    const output = await convertMarkdownWithReferenceDocxToBuffer(
+      "# Reused successfully",
+      generated,
+    );
+    expect(
+      await xml(await JSZip.loadAsync(output), "word/document.xml"),
+    ).toContain("Reused successfully");
+  });
+
   it("rejects unsupported active header/footer relationship constructs", async () => {
     const reference = await createReferenceFixture(async (zip) => {
       const relsPath = "word/_rels/header1.xml.rels";

--- a/tests/security-regressions.test.ts
+++ b/tests/security-regressions.test.ts
@@ -119,6 +119,25 @@ describe("Security regressions", () => {
     );
   });
 
+  it("runs trusted text replacement callbacks once per matching section", async () => {
+    let calls = 0;
+    const blob = await convertMarkdownToDocx("", {
+      sections: [{ markdown: "TOKEN" }, { markdown: "TOKEN" }],
+      textReplacementMode: "trusted",
+      textReplacements: [
+        {
+          find: "TOKEN",
+          replace: () => `replacement-${++calls}`,
+        },
+      ],
+    });
+
+    const documentXml = await getDocumentXml(blob);
+    expect(calls).toBe(2);
+    expect(documentXml).toContain("replacement-1");
+    expect(documentXml).toContain("replacement-2");
+  });
+
   it("rejects invalid textReplacementMode values", async () => {
     await expect(
       convertMarkdownToDocx("Hello", {


### PR DESCRIPTION
## Summary

- reject malformed XML across required and recursively imported reference-DOCX XML parts
- prepare and reuse each post-replacement, post-plugin AST so callbacks run once and caption discovery matches rendering
- preserve task-list markers/checkboxes for plugin blocks, enforce strict plugin image alt text, and recursively count plugin output
- emit unique built-in Word style IDs so generated DOCX files can be reused as reference input
- retain the v2-compatible `MarkdownConversionError` constructor context
- refresh vulnerable transitive dependencies within existing ranges

## Security dependency updates

- `brace-expansion`: 1.1.15 → 1.1.16 and 5.0.6 → 5.0.7
- `js-yaml`: 3.14.2 → 3.15.0 and 4.2.0 → 4.3.0
- bundled `undici`: 6.26.0 → 6.27.0
- transitive `npm`: 11.17.0 → 11.18.0 and bundled `tar`: 7.5.16 → 7.5.19

## Validation

- `npm ci`
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand` — 14 suites, 242 tests
- `npm run test:consumer` — Node16, NodeNext, bundler
- `npm pack --dry-run`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm audit` — 0 vulnerabilities
- generated and reference-round-trip DOCX probes: all XML/relationship parts parse; style IDs are unique; bookmark/NOTEREF and cached REF behavior preserved

Targets `feature/v3` so merging this PR updates #85. This PR does not merge or retarget the release PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch core conversion (AST reuse, styles, captions/plugins) and reference-DOCX XML validation; behavior is well-tested but affects document structure and reference round-trips.
> 
> **Overview**
> Addresses several v3 release blockers around **correct DOCX output**, **reference-DOCX safety**, and **plugin/caption consistency**.
> 
> **Word styles** no longer append duplicate built-in style IDs via `paragraphStyles`; `buildDefaultStyles` customizes the docx library’s default Title/Heading/Strong definitions so generated files have unique style IDs and can be reused as reference DOCX input.
> 
> **Conversion pipeline** prepares each section’s AST once (`parse` → text replacements → plugin `transformAst`), reuses it for rendering, and builds the cross-reference registry from that post-transform AST so caption discovery, trusted replacement callbacks, and final output stay aligned (including plugin-added captions/tables).
> 
> **Plugins and lists**: task-list markers/checkboxes stay on the same paragraph as plugin output; plugin images get strict alt validation and limit placeholders include task markers; `maxElements` counts plugin inline/table output recursively; accessibility alt errors propagate instead of being swallowed by fallback.
> 
> **Reference DOCX** `assertSafeXml` now parses XML with `@xmldom/xmldom` (not just DTD/entity checks) for required and imported parts.
> 
> **API**: `MarkdownConversionError.context` is typed as `unknown` again for v2 consumer compatibility.
> 
> **Dependencies**: lockfile bumps for `js-yaml`, `brace-expansion`, bundled `npm`/`tar`/`undici`, etc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdeb2c23e2149ad039fcc77ff10d6b8b74b4db64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->