### PR TITLE
fix: restore browser bundle compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Verify package consumer imports
         run: npm run test:consumer
 
+      - name: Verify Next.js client bundle
+        run: npm run test:browser-bundle
+
       - name: Run tests
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ const blob = await convertMarkdownToDocx("# Hello\n\nWorld.");
 downloadDocx(blob, "hello.docx");
 ```
 
+Browser conversion supports Markdown without remote images, embedded `data:`
+image URLs, and image bytes returned by trusted renderer plugins/callbacks.
+HTTP(S) Markdown images render as visible fallback text in browser builds, even
+if `imageHandling.remote.enabled` is set. Browsers do not expose the DNS and
+connection controls needed to apply the package's server-side SSRF protections.
+Convert on a trusted Node.js endpoint when remote images must be fetched.
+
 ### Node.js
 
 ```typescript
@@ -180,6 +187,8 @@ await fs.writeFile("output.docx", buffer);
 ### React
 
 ```tsx
+"use client";
+
 import { useState } from "react";
 import { convertMarkdownToDocx, downloadDocx } from "@mohtasham/md-to-docx";
 
@@ -199,6 +208,10 @@ export function MarkdownExporter() {
   );
 }
 ```
+
+This root import is supported in client components, including Next.js
+Turbopack builds. The same browser image boundary applies: use `data:` images
+or perform conversion in a Node.js route when Markdown contains remote images.
 
 ## Features
 
@@ -915,7 +928,7 @@ await convertMarkdownToDocx(markdown, {
 | Blockquotes       | `> text`                       |                                                      |
 | Callouts          | `> [!NOTE]`                    | GitHub-style callout blocks                          |
 | Links             | `[text](url)`                  |                                                      |
-| Images            | `![alt](url)`                  | HTTP(S) and `data:` URLs; supports `#w=...&h=...` sizing |
+| Images            | `![alt](url)`                  | `data:` URLs in all runtimes; opt-in HTTP(S) fetching in Node.js; supports `#w=...&h=...` sizing |
 | Figure captions   | `: Caption {#fig:id}`          | Place after a standalone image; automatic numbering      |
 | Table captions    | `: Caption {#tbl:id}`          | Place after a GFM table; automatic numbering             |
 | Cross-references  | `[@fig:id]`, `[@tbl:id]`       | Native clickable Word references; forward refs supported |
@@ -1018,6 +1031,35 @@ interface Options {
   imageHandling?: ImageHandlingOptions;
 }
 ```
+
+#### `ImageHandlingOptions`
+
+Remote image fetching is disabled by default. In Node.js, enabling it preserves
+the full SSRF policy: HTTPS-only URLs, optional exact-host allowlisting,
+private-network blocking, DNS-pinned TLS connections, redirect limits, byte
+limits, and a total timeout. An explicitly empty `allowedHosts` array denies
+every host.
+
+```typescript
+await convertMarkdownToDocx(markdown, {
+  imageHandling: {
+    remote: {
+      enabled: true,
+      allowedHosts: ["images.example.com"],
+    },
+    maxImages: 25,
+    maxImageBytes: 5 * 1024 * 1024,
+    fetchTimeoutMs: 10_000,
+    maxRedirects: 3,
+    maxUrlLength: 2048,
+  },
+});
+```
+
+`remote.enabled` and `remote.allowedHosts` apply only to Node.js. Browser builds
+never issue remote image requests from Markdown; those images become visible
+fallback paragraphs. Browser callers can use `data:` image URLs, return trusted
+bytes from a plugin or diagram renderer, or send the conversion to a server.
 
 #### `CaptionOptions`
 
@@ -1297,7 +1339,8 @@ All conversion failures throw `MarkdownConversionError` (exported from the root)
 ## Requirements
 
 - **Node.js** ≥ 18 (ESM-only package)
-- **Browsers:** any evergreen browser that supports ES2020 + Blobs
+- **Browsers:** any evergreen browser that supports ES2020 + Blobs; remote
+  Markdown images require server-side conversion
 
 ## Install as an agent skill
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -4,6 +4,8 @@ export default {
   setupFilesAfterEnv: ["<rootDir>/tests/jest.polyfills.mjs"],
   extensionsToTreatAsEsm: [".ts"],
   moduleNameMapper: {
+    "^#secure-image-fetch$":
+      "<rootDir>/src/utils/secureImageFetch.node.ts",
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "eslint": "^9.39.4",
         "globals": "^17.6.0",
         "jest": "^29.7.0",
+        "next": "15.5.22",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
         "semantic-release": "25.0.3",
         "ts-jest": "^29.1.2",
         "typescript": "^5.8.2"
@@ -590,6 +593,17 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -838,6 +852,497 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1207,6 +1712,149 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -2084,6 +2732,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3189,6 +3847,13 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3594,6 +4259,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -7227,6 +7903,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.22",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -9693,6 +10422,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9825,6 +10602,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-is": {
@@ -10119,6 +10919,13 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -10551,6 +11358,66 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -10721,6 +11588,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -10904,6 +11781,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/super-regex": {
@@ -11282,6 +12183,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     },
     "./package.json": "./package.json"
   },
+  "imports": {
+    "#secure-image-fetch": {
+      "browser": "./dist/utils/secureImageFetch.browser.js",
+      "node": "./dist/utils/secureImageFetch.node.js",
+      "default": "./dist/utils/secureImageFetch.browser.js"
+    }
+  },
   "bin": {
     "md-to-docx": "dist/cli.js"
   },
@@ -20,6 +27,7 @@
     "build": "tsc",
     "lint": "eslint src tests",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.mjs",
+    "test:browser-bundle": "npm run build && node tests/browser-bundle.mjs",
     "test:consumer": "node tests/package-consumer.mjs",
     "test:package-managers": "node tests/package-manager-consumer.mjs pnpm && node tests/package-manager-consumer.mjs bun",
     "test:package-manager": "node tests/package-manager-consumer.mjs",
@@ -63,6 +71,9 @@
     "eslint": "^9.39.4",
     "globals": "^17.6.0",
     "jest": "^29.7.0",
+    "next": "15.5.22",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "semantic-release": "25.0.3",
     "ts-jest": "^29.1.2",
     "typescript": "^5.8.2"

--- a/src/renderers/imageRenderer.ts
+++ b/src/renderers/imageRenderer.ts
@@ -5,7 +5,7 @@ import { resolveFontFamily } from "../utils/styleUtils.js";
 import {
   fetchRemoteImage,
   resolveImageHandlingOptions,
-} from "../utils/secureImageFetch.js";
+} from "#secure-image-fetch";
 import { MarkdownConversionError } from "../errors.js";
 import { throwIfAborted } from "../processingLimits.js";
 import {
@@ -17,8 +17,8 @@ import {
 export {
   DEFAULT_IMAGE_HANDLING,
   resolveImageHandlingOptions,
-} from "../utils/secureImageFetch.js";
-export type { ResolvedImageHandlingOptions } from "../utils/secureImageFetch.js";
+} from "#secure-image-fetch";
+export type { ResolvedImageHandlingOptions } from "#secure-image-fetch";
 
 /**
  * Upper bound for rendered image dimensions in pixels. Hints come from

--- a/src/types.ts
+++ b/src/types.ts
@@ -577,13 +577,15 @@ export interface TocOptions {
 
 export interface RemoteImageHandlingOptions {
   /**
-   * Allow fetching remote images. Defaults to false.
+   * Allow fetching remote images in Node.js. Defaults to false. Browser builds
+   * always reject remote image fetching because they cannot enforce the DNS/IP
+   * validation and connection pinning required by the server-side SSRF policy.
    */
   enabled?: boolean;
   /**
-   * Optional exact host allowlist. Host names are compared case-insensitively.
-   * When provided, the list fails closed: an empty array denies every host.
-   * Omit the option to allow any (public) host.
+   * Node.js-only exact host allowlist. Host names are compared
+   * case-insensitively. When provided, the list fails closed: an empty array
+   * denies every host. Omit the option to allow any public host.
    */
   allowedHosts?: string[];
 }

--- a/src/utils/imageHandling.ts
+++ b/src/utils/imageHandling.ts
@@ -1,0 +1,53 @@
+import type { ImageHandlingOptions } from "../types.js";
+
+export interface ResolvedImageHandlingOptions {
+  remote: {
+    enabled: boolean;
+    allowedHosts?: string[];
+  };
+  dataUrls: {
+    enabled: boolean;
+  };
+  maxImages: number;
+  maxImageBytes: number;
+  fetchTimeoutMs: number;
+  maxRedirects: number;
+  maxUrlLength: number;
+}
+
+export const DEFAULT_IMAGE_HANDLING: ResolvedImageHandlingOptions = {
+  remote: {
+    enabled: false,
+  },
+  dataUrls: {
+    enabled: true,
+  },
+  maxImages: 50,
+  maxImageBytes: 5 * 1024 * 1024,
+  fetchTimeoutMs: 10_000,
+  maxRedirects: 3,
+  maxUrlLength: 2048,
+};
+
+export function resolveImageHandlingOptions(
+  options?: ImageHandlingOptions
+): ResolvedImageHandlingOptions {
+  return {
+    remote: {
+      enabled: options?.remote?.enabled === true,
+      allowedHosts: options?.remote?.allowedHosts?.map((host) =>
+        host.trim().toLowerCase()
+      ),
+    },
+    dataUrls: {
+      enabled: options?.dataUrls?.enabled !== false,
+    },
+    maxImages: options?.maxImages ?? DEFAULT_IMAGE_HANDLING.maxImages,
+    maxImageBytes:
+      options?.maxImageBytes ?? DEFAULT_IMAGE_HANDLING.maxImageBytes,
+    fetchTimeoutMs:
+      options?.fetchTimeoutMs ?? DEFAULT_IMAGE_HANDLING.fetchTimeoutMs,
+    maxRedirects: options?.maxRedirects ?? DEFAULT_IMAGE_HANDLING.maxRedirects,
+    maxUrlLength: options?.maxUrlLength ?? DEFAULT_IMAGE_HANDLING.maxUrlLength,
+  };
+}

--- a/src/utils/secureImageFetch.browser.ts
+++ b/src/utils/secureImageFetch.browser.ts
@@ -1,0 +1,31 @@
+import { throwIfAborted } from "../processingLimits.js";
+import type { ResolvedImageHandlingOptions } from "./imageHandling.js";
+
+export {
+  DEFAULT_IMAGE_HANDLING,
+  resolveImageHandlingOptions,
+} from "./imageHandling.js";
+export type { ResolvedImageHandlingOptions } from "./imageHandling.js";
+
+export interface RemoteImage {
+  bytes: Uint8Array;
+  contentType: string;
+  finalUrl: string;
+}
+
+/**
+ * Browsers cannot perform the DNS and connection pinning required by the
+ * server-side SSRF policy. Remote Markdown images therefore fail closed in the
+ * browser build, even when `remote.enabled` is true. Data URLs and caller-
+ * supplied image bytes remain supported.
+ */
+export async function fetchRemoteImage(
+  _initialUrl: string,
+  _options: ResolvedImageHandlingOptions,
+  signal?: AbortSignal
+): Promise<RemoteImage> {
+  throwIfAborted(signal);
+  throw new Error(
+    "Remote image fetching is unavailable in browsers; use a data URL, a trusted renderer/plugin, or perform conversion on the server"
+  );
+}

--- a/src/utils/secureImageFetch.node.ts
+++ b/src/utils/secureImageFetch.node.ts
@@ -1,60 +1,14 @@
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { Agent, buildConnector } from "undici";
-import { ImageHandlingOptions } from "../types.js";
 import { throwIfAborted } from "../processingLimits.js";
+import type { ResolvedImageHandlingOptions } from "./imageHandling.js";
 
-export interface ResolvedImageHandlingOptions {
-  remote: {
-    enabled: boolean;
-    allowedHosts?: string[];
-  };
-  dataUrls: {
-    enabled: boolean;
-  };
-  maxImages: number;
-  maxImageBytes: number;
-  fetchTimeoutMs: number;
-  maxRedirects: number;
-  maxUrlLength: number;
-}
-
-export const DEFAULT_IMAGE_HANDLING: ResolvedImageHandlingOptions = {
-  remote: {
-    enabled: false,
-  },
-  dataUrls: {
-    enabled: true,
-  },
-  maxImages: 50,
-  maxImageBytes: 5 * 1024 * 1024,
-  fetchTimeoutMs: 10_000,
-  maxRedirects: 3,
-  maxUrlLength: 2048,
-};
-
-export function resolveImageHandlingOptions(
-  options?: ImageHandlingOptions
-): ResolvedImageHandlingOptions {
-  return {
-    remote: {
-      enabled: options?.remote?.enabled === true,
-      allowedHosts: options?.remote?.allowedHosts?.map((host) =>
-        host.trim().toLowerCase()
-      ),
-    },
-    dataUrls: {
-      enabled: options?.dataUrls?.enabled !== false,
-    },
-    maxImages: options?.maxImages ?? DEFAULT_IMAGE_HANDLING.maxImages,
-    maxImageBytes:
-      options?.maxImageBytes ?? DEFAULT_IMAGE_HANDLING.maxImageBytes,
-    fetchTimeoutMs:
-      options?.fetchTimeoutMs ?? DEFAULT_IMAGE_HANDLING.fetchTimeoutMs,
-    maxRedirects: options?.maxRedirects ?? DEFAULT_IMAGE_HANDLING.maxRedirects,
-    maxUrlLength: options?.maxUrlLength ?? DEFAULT_IMAGE_HANDLING.maxUrlLength,
-  };
-}
+export {
+  DEFAULT_IMAGE_HANDLING,
+  resolveImageHandlingOptions,
+} from "./imageHandling.js";
+export type { ResolvedImageHandlingOptions } from "./imageHandling.js";
 
 function isPrivateIPv4(address: string): boolean {
   const parts = address.split(".").map((part) => Number(part));
@@ -138,10 +92,6 @@ function isBlockedIpAddress(address: string): boolean {
     return isPrivateIPv6(address);
   }
   return true;
-}
-
-function usePinnedHttpsConnections(): boolean {
-  return typeof process !== "undefined" && process.versions?.node != null;
 }
 
 function enforceRemoteHttpsPolicy(
@@ -230,31 +180,20 @@ function buildPinnedHttpsAgent(
 }
 
 /**
- * Validates policy + DNS/IP rules. On Node, returns an Undici Agent that pins TLS
- * to the resolved address so fetch cannot reconnect via a second DNS lookup (rebinding).
- * In browser-like runtimes without process.versions.node, returns undefined and callers use plain fetch after validation.
+ * Validates policy + DNS/IP rules and returns an Undici Agent that pins TLS to
+ * the resolved address so fetch cannot reconnect via a second DNS lookup
+ * (rebinding).
  */
-async function preparePinnedAgentIfNeeded(
+async function preparePinnedAgent(
   url: URL,
   options: ResolvedImageHandlingOptions,
   dnsTimeoutMs: number
-): Promise<Agent | undefined> {
+): Promise<Agent> {
   enforceRemoteHttpsPolicy(url, options);
 
   const literalFamily = isIP(url.hostname);
   const port = Number(url.port) || 443;
   const tlsServerName = url.hostname;
-
-  if (!usePinnedHttpsConnections()) {
-    if (literalFamily !== 0) {
-      if (isBlockedIpAddress(url.hostname)) {
-        throw new Error("Remote image host resolves to a blocked network address");
-      }
-      return undefined;
-    }
-    await resolveVerifiedAddresses(url.hostname, dnsTimeoutMs);
-    return undefined;
-  }
 
   if (literalFamily !== 0) {
     if (isBlockedIpAddress(url.hostname)) {
@@ -470,7 +409,7 @@ export async function fetchRemoteImage(
 
       await closePinned();
       pinnedAgent = await abortableCallerPromise(
-        preparePinnedAgentIfNeeded(currentUrl, options, dnsBudgetMs),
+        preparePinnedAgent(currentUrl, options, dnsBudgetMs),
         signal
       );
 

--- a/tests/browser-bundle.mjs
+++ b/tests/browser-bundle.mjs
@@ -8,6 +8,9 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
+// Keep the fixture under the repository's node_modules so ancestor lookup finds
+// next/react/react-dom there, while the app resolves md-to-docx from its packed
+// copy in appDir/node_modules first.
 const tempRoot = fs.mkdtempSync(
   path.join(repoRoot, "node_modules", ".browser-bundle-")
 );
@@ -136,11 +139,16 @@ try {
     throw new Error("Next.js did not emit any client JavaScript chunks");
   }
 
-  const forbiddenImports = [
-    "node:dns/promises",
-    "node:net",
-    'from"undici"',
-    'require("undici")',
+  const forbiddenSubstrings = ["node:dns/promises", "node:net"];
+  const forbiddenPatterns = [
+    {
+      label: "undici package specifier",
+      pattern: /["']undici(?:\/[^"']*)?["']/,
+    },
+    {
+      label: "bundled undici module",
+      pattern: /["'][^"']*node_modules\/undici(?:\/[^"']*)?["']/,
+    },
   ];
   let foundBrowserRemoteImagePolicy = false;
   for (const filePath of clientFiles) {
@@ -148,10 +156,17 @@ try {
     foundBrowserRemoteImagePolicy ||= source.includes(
       "Remote image fetching is unavailable in browsers"
     );
-    for (const forbiddenImport of forbiddenImports) {
-      if (source.includes(forbiddenImport)) {
+    for (const forbidden of forbiddenSubstrings) {
+      if (source.includes(forbidden)) {
         throw new Error(
-          `Browser chunk ${path.relative(appDir, filePath)} contains ${forbiddenImport}`
+          `Browser chunk ${path.relative(appDir, filePath)} contains ${forbidden}`
+        );
+      }
+    }
+    for (const { label, pattern } of forbiddenPatterns) {
+      if (pattern.test(source)) {
+        throw new Error(
+          `Browser chunk ${path.relative(appDir, filePath)} contains ${label} (${pattern})`
         );
       }
     }

--- a/tests/browser-bundle.mjs
+++ b/tests/browser-bundle.mjs
@@ -1,0 +1,170 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const tempRoot = fs.mkdtempSync(
+  path.join(repoRoot, "node_modules", ".browser-bundle-")
+);
+const packDir = path.join(tempRoot, "pack");
+const appDir = path.join(tempRoot, "app");
+const packageDir = path.join(
+  appDir,
+  "node_modules",
+  "@mohtasham",
+  "md-to-docx"
+);
+const nextBin = path.join(
+  repoRoot,
+  "node_modules",
+  "next",
+  "dist",
+  "bin",
+  "next"
+);
+
+function write(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function walkJavaScriptFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return walkJavaScriptFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith(".js") ? [entryPath] : [];
+  });
+}
+
+try {
+  fs.mkdirSync(packDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+
+  const tarballName = execFileSync(
+    "npm",
+    ["pack", "--ignore-scripts", "--pack-destination", packDir, "--silent"],
+    { cwd: repoRoot, encoding: "utf8" }
+  ).trim();
+  execFileSync(
+    "tar",
+    [
+      "-xzf",
+      path.join(packDir, tarballName),
+      "-C",
+      packageDir,
+      "--strip-components=1",
+    ],
+    { stdio: "inherit" }
+  );
+
+  write(
+    path.join(appDir, "package.json"),
+    `${JSON.stringify(
+      {
+        private: true,
+        scripts: { build: "next build --turbopack" },
+        dependencies: {
+          "@mohtasham/md-to-docx":
+            "file:./node_modules/@mohtasham/md-to-docx",
+          next: "15.5.22",
+          react: "19.2.4",
+          "react-dom": "19.2.4",
+        },
+      },
+      null,
+      2
+    )}${os.EOL}`
+  );
+  write(
+    path.join(appDir, "next.config.mjs"),
+    "export default { output: 'export' };\n"
+  );
+  write(
+    path.join(appDir, "app", "layout.js"),
+    [
+      'import { createElement } from "react";',
+      "",
+      "export default function Layout({ children }) {",
+      '  return createElement("html", { lang: "en" },',
+      '    createElement("body", null, children));',
+      "}",
+      "",
+    ].join(os.EOL)
+  );
+  write(
+    path.join(appDir, "app", "page.js"),
+    [
+      '"use client";',
+      "",
+      'import { createElement } from "react";',
+      "import {",
+      "  convertMarkdownToDocx,",
+      "  downloadDocx,",
+      '} from "@mohtasham/md-to-docx";',
+      "",
+      "export default function Page() {",
+      "  async function exportDocx() {",
+      '    const blob = await convertMarkdownToDocx("# Browser export\\n\\nNo remote images.");',
+      '    await downloadDocx(blob, "browser-export.docx");',
+      "  }",
+      "",
+      '  return createElement("button", { onClick: exportDocx }, "Export DOCX");',
+      "}",
+      "",
+    ].join(os.EOL)
+  );
+
+  execFileSync(process.execPath, [nextBin, "build", "--turbopack"], {
+    cwd: appDir,
+    env: {
+      ...process.env,
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+    stdio: "inherit",
+  });
+
+  const clientChunkDir = path.join(appDir, ".next", "static", "chunks");
+  const clientFiles = walkJavaScriptFiles(clientChunkDir);
+  if (clientFiles.length === 0) {
+    throw new Error("Next.js did not emit any client JavaScript chunks");
+  }
+
+  const forbiddenImports = [
+    "node:dns/promises",
+    "node:net",
+    'from"undici"',
+    'require("undici")',
+  ];
+  let foundBrowserRemoteImagePolicy = false;
+  for (const filePath of clientFiles) {
+    const source = fs.readFileSync(filePath, "utf8");
+    foundBrowserRemoteImagePolicy ||= source.includes(
+      "Remote image fetching is unavailable in browsers"
+    );
+    for (const forbiddenImport of forbiddenImports) {
+      if (source.includes(forbiddenImport)) {
+        throw new Error(
+          `Browser chunk ${path.relative(appDir, filePath)} contains ${forbiddenImport}`
+        );
+      }
+    }
+  }
+  if (!foundBrowserRemoteImagePolicy) {
+    throw new Error(
+      "Next.js client chunks did not select the browser image-fetch implementation"
+    );
+  }
+
+  console.log(
+    `Verified ${clientFiles.length} Next.js/Turbopack client chunks without Node image-fetch dependencies`
+  );
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/tests/browser-image-fetch.test.ts
+++ b/tests/browser-image-fetch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  fetchRemoteImage,
+  resolveImageHandlingOptions,
+} from "../src/utils/secureImageFetch.browser";
+
+describe("browser remote image policy", () => {
+  it("fails closed without issuing a request even when remote images are enabled", async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected browser fetch"));
+    const options = resolveImageHandlingOptions({
+      remote: { enabled: true, allowedHosts: ["images.example.com"] },
+    });
+
+    await expect(
+      fetchRemoteImage("https://images.example.com/image.png", options)
+    ).rejects.toThrow("Remote image fetching is unavailable in browsers");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- split remote-image fetching into explicit browser and Node implementations selected through a private conditional package import
- keep the hardened Node SSRF path, including HTTPS enforcement, allowlisting, DNS/IP validation, DNS-pinned Undici connections, redirect limits, byte limits, and timeouts
- make browser remote-image behavior fail closed while preserving ordinary Markdown conversion, data URL images, and caller-provided image bytes
- document client-component support and the browser remote-image boundary
- add a real Next.js/Turbopack client-build regression to CI

## Root cause

The root package graph statically reached `src/utils/secureImageFetch.ts` through `index.ts -> modelToDocx.ts -> imageRenderer.ts`. That module imported `node:dns/promises`, `node:net`, and `undici` at top level. Turbopack resolved those imports while constructing the browser chunk, so runtime environment checks could not prevent the client build from failing.

## Compatibility and behavior

Node.js continues to use the existing secure, opt-in remote-image implementation. Browser builds never issue remote Markdown-image requests, even when `imageHandling.remote.enabled` is set; remote images render the existing visible fallback paragraph instead. Browser conversion without remote images remains supported, including `data:` images and trusted renderer/plugin bytes.

## Validation

- `npm run build`
- `npm run test:browser-bundle` — Next.js 15.5.22 Turbopack production build; verified 18 emitted client chunks select the browser implementation and contain no Node image-fetch dependencies
- `npm test -- --runInBand` — 244 tests passed
- `npm run lint`
- `npm run test:consumer` — Node16, NodeNext, and bundler resolution
- `npm run test:package-manager -- pnpm` — packaged API and CLI smoke tests
- `npm pack --dry-run --json --ignore-scripts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the security boundary for browser remote images (now fail-closed) and touches SSRF-sensitive Node fetch code, though Node behavior is intended to stay hardened; regression coverage is added via bundle and unit tests.
> 
> **Overview**
> Fixes **Next.js/Turbopack client builds** that previously pulled `node:dns/promises`, `node:net`, and `undici` through a single `secureImageFetch` module on the main import graph.
> 
> Remote image handling is split into **browser** and **Node** implementations wired through a private `package.json` `imports` map (`#secure-image-fetch`); `imageRenderer` now imports that alias instead of a shared file. Shared option defaults live in `imageHandling.ts`, while **Node** keeps the hardened fetch path (HTTPS, allowlists, DNS/IP checks, pinned Undici) with the old “browser runtime” unpinned fallback removed. **Browser** `fetchRemoteImage` always throws (no network), so `imageHandling.remote.enabled` does not fetch in the client; `data:` URLs and plugin-supplied bytes stay supported.
> 
> CI gains **`npm run test:browser-bundle`**, which packs the library, runs a minimal Next 15 Turbopack client app, and asserts client chunks omit Node networking deps while including the browser policy string. README and types document the browser vs Node image boundary and React `"use client"` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84fdb6031e9b7a7108050f9a2172111200a7de27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent image-handling defaults for timeouts, redirects, URL lengths, and image sizes.
  * Browser conversions support data URLs while blocking remote image fetching.
  * Node.js remote image handling supports host allowlists and SSRF protections.

* **Documentation**
  * Clarified browser and Node.js image-handling behavior, configuration, and React client usage.

* **Tests**
  * Added browser bundle verification to ensure server-only networking code is excluded.
  * Added coverage confirming browser remote image requests are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->